### PR TITLE
feat(start): add Docker daemon and network pre-flight checks

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -28,6 +28,12 @@ IMAGE_TAG="${2:-base}"
 
 VALID_IMAGES="base crypto systems research"
 
+if ! docker info > /dev/null 2>&1; then
+    echo "Error: Docker daemon is not running."
+    echo "Start Docker and try again."
+    exit 1
+fi
+
 if [ ! -d "$PROJECT_DIR" ]; then
     echo "Error: '$PROJECT_DIR' is not a directory."
     exit 1
@@ -44,6 +50,12 @@ IMAGE_NAME="claude-${IMAGE_TAG}"
 if ! docker image inspect "$IMAGE_NAME" > /dev/null 2>&1; then
     echo "Error: image '$IMAGE_NAME' does not exist."
     echo "Build it first with: ./build.sh $IMAGE_TAG"
+    exit 1
+fi
+
+if ! docker network inspect claude-net > /dev/null 2>&1; then
+    echo "Error: network 'claude-net' does not exist."
+    echo "Create it with: docker network create --driver bridge claude-net"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Checks that the Docker daemon is reachable (`docker info`) before any other Docker call
- Checks that the `claude-net` bridge network exists (`docker network inspect`) before `docker run`
- Both failures print a clear error message with the exact remediation command and exit 1, consistent with existing guard style

Closes #1

## Test plan

- [ ] Docker daemon not running → `Error: Docker daemon is not running. / Start Docker and try again.`, exit 1
- [ ] `claude-net` absent (`docker network rm claude-net`) → `Error: network 'claude-net' does not exist. / Create it with: docker network create --driver bridge claude-net`, exit 1
- [ ] Both preconditions met → behaviour unchanged from before
- [ ] Existing guards (bad image tag, missing project dir, image not built) still work correctly