### PR TITLE
feat(entrypoint): enforce Co-Authored-By policy via commit-msg hook

### DIFF
--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -107,4 +107,31 @@ fi
 
 echo "[entrypoint] Node.js addon check complete"
 
+echo "[entrypoint] Checking /workspace for commit-msg hook"
+
+HOOK_DIR="/workspace/.git/hooks"
+HOOK_PATH="${HOOK_DIR}/commit-msg"
+
+if [ ! -d "/workspace/.git" ]; then
+    echo "[entrypoint] No .git directory found — commit-msg hook installation skipped"
+elif [ -f "$HOOK_PATH" ]; then
+    echo "[entrypoint] commit-msg hook already present at $HOOK_PATH — skipping"
+    echo "[entrypoint] Invoke the commit-hook-setup skill to inspect or update it"
+else
+    mkdir -p "$HOOK_DIR"
+    cat > "$HOOK_PATH" << 'HOOK'
+#!/usr/bin/env bash
+# Installed by claude-sandbox entrypoint
+if grep -qi "^Co-Authored-By:" "$1"; then
+    echo "ERROR: Co-Authored-By lines are not allowed in this repository." >&2
+    echo "       Remove the trailer and commit again." >&2
+    exit 1
+fi
+HOOK
+    chmod +x "$HOOK_PATH"
+    echo "[entrypoint] commit-msg hook installed at $HOOK_PATH"
+fi
+
+echo "[entrypoint] Commit-msg hook check complete"
+
 exec "$@"

--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -119,15 +119,7 @@ elif [ -f "$HOOK_PATH" ]; then
     echo "[entrypoint] Invoke the commit-hook-setup skill to inspect or update it"
 else
     mkdir -p "$HOOK_DIR"
-    cat > "$HOOK_PATH" << 'HOOK'
-#!/usr/bin/env bash
-# Installed by claude-sandbox entrypoint
-if grep -qi "^Co-Authored-By:" "$1"; then
-    echo "ERROR: Co-Authored-By lines are not allowed in this repository." >&2
-    echo "       Remove the trailer and commit again." >&2
-    exit 1
-fi
-HOOK
+    cp "${HOME}/.claude/hooks/commit-msg" "$HOOK_PATH"
     chmod +x "$HOOK_PATH"
     echo "[entrypoint] commit-msg hook installed at $HOOK_PATH"
 fi

--- a/global-claude/hooks/commit-msg
+++ b/global-claude/hooks/commit-msg
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Installed by claude-sandbox global layer
+if grep -qi "^Co-Authored-By:" "$1"; then
+    echo "ERROR: Co-Authored-By lines are not allowed in this repository." >&2
+    echo "       Remove the trailer and commit again." >&2
+    exit 1
+fi

--- a/global-claude/skills/commit-hook-setup/SKILL.md
+++ b/global-claude/skills/commit-hook-setup/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: commit-hook-setup
+description: >
+  Install or verify the commit-msg hook in /workspace. Invoke when the
+  entrypoint log shows "hook already present" and Co-Authored-By
+  enforcement is not yet in place, or when asked to set up or inspect
+  commit enforcement.
+---
+
+# Commit Hook Setup
+
+## When to invoke
+- Entrypoint startup log says "commit-msg hook already present" and you
+  need to verify or update it
+- First session on a new repository where an existing hook was found
+- Operator asks to install, verify, or update the commit-msg hook
+
+## Step 1 — Inspect
+
+```bash
+cat /workspace/.git/hooks/commit-msg 2>/dev/null || echo "(no hook present)"
+```
+
+## Step 2 — Decide
+
+**No hook present** → proceed to Step 3. Ask the operator to confirm before writing.
+
+**Hook present and contains `Co-Authored-By` check** → compliant. Report and stop.
+
+**Hook present but does not contain the check** → show the existing content to the
+operator. Ask them to choose:
+  a) Replace with the standard hook (loses existing logic)
+  b) Append the Co-Authored-By check to the existing hook
+  c) Leave as-is (enforcement gap — note it explicitly)
+
+Never overwrite silently.
+
+## Step 3 — Install standard hook
+
+```bash
+cat > /workspace/.git/hooks/commit-msg << 'HOOK'
+#!/usr/bin/env bash
+# Installed by claude-sandbox global layer
+if grep -qi "^Co-Authored-By:" "$1"; then
+    echo "ERROR: Co-Authored-By lines are not allowed in this repository." >&2
+    echo "       Remove the trailer and commit again." >&2
+    exit 1
+fi
+HOOK
+chmod +x /workspace/.git/hooks/commit-msg
+```
+
+Verify:
+```bash
+ls -la /workspace/.git/hooks/commit-msg
+```

--- a/global-claude/skills/commit-hook-setup/SKILL.md
+++ b/global-claude/skills/commit-hook-setup/SKILL.md
@@ -38,19 +38,12 @@ Never overwrite silently.
 ## Step 3 — Install standard hook
 
 ```bash
-cat > /workspace/.git/hooks/commit-msg << 'HOOK'
-#!/usr/bin/env bash
-# Installed by claude-sandbox global layer
-if grep -qi "^Co-Authored-By:" "$1"; then
-    echo "ERROR: Co-Authored-By lines are not allowed in this repository." >&2
-    echo "       Remove the trailer and commit again." >&2
-    exit 1
-fi
-HOOK
+cp ~/.claude/hooks/commit-msg /workspace/.git/hooks/commit-msg
 chmod +x /workspace/.git/hooks/commit-msg
 ```
 
 Verify:
 ```bash
 ls -la /workspace/.git/hooks/commit-msg
+cat /workspace/.git/hooks/commit-msg
 ```


### PR DESCRIPTION
## Summary

- Installs a `commit-msg` hook at container startup that rejects commits containing `Co-Authored-By:` trailers, converting the existing instruction-only policy in `global-claude/CLAUDE.md` into a technical gate
- Adds a `commit-hook-setup` skill for the edge case where a project already has a `commit-msg` hook (entrypoint skips that case; skill guides the operator through inspecting and optionally merging)
- Fixes a heredoc quoting fragility found during testing: the original implementation embedded the hook script in a heredoc requiring a single-quoted delimiter (`<< 'HOOK'`); when an in-session agent re-typed the command it dropped the quotes, producing `grep … ""` (empty argument) that always exits 0. Fix promotes the hook to a standalone file in the global layer (`global-claude/hooks/commit-msg`) and replaces both heredocs with a plain `cp`

## Commits

- `bb059ab` `feat(entrypoint)` — hook installation block + skill
- `e8c47e9` `build(global-claude)` — canonical hook file
- `c7b0a3a` `fix` — replace heredocs with cp

## Test plan

- [x] Fresh repo: container startup log shows `commit-msg hook installed`; `cat /workspace/.git/hooks/commit-msg` contains literal `"$1"`, not `""`
- [x] Second startup on same repo: log shows `hook already present — skipping`; file unchanged
- [x] Hook rejection: commit message with `Co-Authored-By:` trailer exits non-zero with the error message
- [x] Hook pass: clean commit message exits 0
- [x] No-git session: log shows `No .git directory found — skipped`; entrypoint continues normally
- [x] Skill path (`commit-hook-setup`): Step 3 `cp ~/.claude/hooks/commit-msg …` installs correct hook without any heredoc