### PR TITLE
docs: add README and user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# claude-sandbox
+
+Docker-based sandboxing for running Claude Code sessions with strict,
+verifiable security controls: non-root execution, dropped capabilities,
+network-egress allowlisting via a Squid proxy, and per-project image
+profiles (crypto, systems, research, or plain web/Python).
+
+Each session runs in an ephemeral container — nothing persists between
+sessions except your project directory and the global instruction layer,
+so there's no state to drift and nothing for one session to leak into the
+next.
+
+## Quickstart
+
+```bash
+docker network create --driver bridge claude-net   # once
+./build.sh                                          # build all images
+./start.sh ~/projects/myproject crypto              # start a session
+```
+
+`crypto` can be `base`, `crypto`, `systems`, or `research` depending on
+your project — see the [user guide](docs/user_guide.md) for how to choose.
+
+## Documentation
+
+| Doc | Covers |
+|---|---|
+| [`docs/user_guide.md`](docs/user_guide.md) | Day-to-day usage: picking a profile, the session lifecycle, adding tools, troubleshooting |
+| [`BUILDING.md`](BUILDING.md) | Build/run/test commands |
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | Image hierarchy and dependency management strategy |
+| [`docs/claude_code_security_plan.md`](docs/claude_code_security_plan.md) | Threat model and security controls |
+| [`docs/squid_proxy_guide.md`](docs/squid_proxy_guide.md) | Outbound network allowlisting |
+| [`docs/designs/`](docs/designs/) | Design documents for individual subsystems (global layer injection, testing harness) |
+| [`docs/designs/docs-as-code-workflow.md`](docs/designs/docs-as-code-workflow.md) | How this project decides what to document and where |

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,75 @@
+# User Guide
+
+Practical, day-to-day usage of claude-sandbox. For build/test commands see
+[`BUILDING.md`](../BUILDING.md); for internals see
+[`ARCHITECTURE.md`](../ARCHITECTURE.md).
+
+## Choosing a profile
+
+| Profile | Use for | Adds on top of `base` |
+|---|---|---|
+| `base` | Web, Python, TypeScript | — |
+| `crypto` | HSM / cryptography | OpenSSL, p11-kit, SoftHSM2, GnuTLS |
+| `systems` | C++ / CMake | CMake, GCC/Clang, GTest, sanitizers |
+| `research` | LaTeX documents | TeX Live, latexmk |
+
+Full hierarchy and rationale: [`ARCHITECTURE.md`](../ARCHITECTURE.md#image-hierarchy).
+
+## Starting a session
+
+```bash
+./start.sh <project_directory> [profile]   # profile defaults to base
+```
+
+Each session is a fresh, ephemeral container: your project directory is
+bind-mounted, the container runs non-root with capabilities dropped and
+outbound network restricted to an allowlist (Anthropic API + package
+registries), and the container is removed when the session ends. Nothing
+in the container's own filesystem persists to the next session — only your
+project directory does. See
+[`docs/claude_code_security_plan.md`](claude_code_security_plan.md) for the
+full threat model and [`docs/squid_proxy_guide.md`](squid_proxy_guide.md)
+for the network allowlist mechanics.
+
+## The global instruction layer
+
+Every session gets `global-claude/CLAUDE.md` (and skills) copied into
+`~/.claude/` at startup, plus a per-profile overlay (`global-<profile>/`,
+if one exists) merged on top. This is how project-independent instructions
+and skills reach every session without being part of any one project. The
+copy is one-way and read-only from the container's perspective — edits
+made inside a session never write back to the host source directories, and
+sessions never see each other's copies. Full mechanism, isolation
+guarantees, and STRIDE analysis: [`docs/designs/global-layer-injection.md`](designs/global-layer-injection.md).
+
+## Adding a tool
+
+Two options, covered in detail in `ARCHITECTURE.md`:
+
+- **Strategy A (default):** add it to the relevant Dockerfile, rebuild.
+  Reproducible, survives every future session.
+- **Strategy B (experiment only):** `docker exec -u root` into a running
+  container to try something without committing to it. Disappears when the
+  container exits — never build a persistent artifact against it. See
+  [`ARCHITECTURE.md`](../ARCHITECTURE.md#strategy-b--ephemeral-install-experiment-first)
+  for the boundary between the two.
+
+## Troubleshooting
+
+- **"broken interpreter reference" / "stale CMake toolchain path" warnings
+  at session start** — usually means a venv or CMake build directory in
+  your project was built against a tool installed via Strategy B that was
+  never promoted to the Dockerfile. The warning names the fix. Background:
+  [`interpreter-presence-health-check.md`](../interpreter-presence-health-check.md),
+  [`workspace-artifact-staleness.md`](../workspace-artifact-staleness.md).
+- **Session start fails with "unknown image" or "image does not exist"** —
+  check the profile name is one of `base`/`crypto`/`systems`/`research`,
+  and that you've built it with `./build.sh <profile>`.
+- **`docker network create` errors because `claude-net` already exists** —
+  expected on any machine that's already run a session; safe to ignore.
+
+## Running the test suite
+
+See [`BUILDING.md`](../BUILDING.md#running-the-test-suite) for `bats`
+invocation. What each test group validates and why:
+[`docs/designs/claude-sandbox-testing-module-sdd.md`](designs/claude-sandbox-testing-module-sdd.md).


### PR DESCRIPTION
## Summary
- Adds a root `README.md`: project pitch, quickstart, and a documentation index linking every existing doc.
- Adds `docs/user_guide.md`: day-to-day usage — choosing a profile, the session lifecycle, the global instruction layer, adding tools, troubleshooting, and running the test suite. Links out to `BUILDING.md`/`ARCHITECTURE.md`/design docs rather than duplicating their content.

## Test plan
- [x] Manually reviewed all internal links resolve against current `main` (including `BUILDING.md#running-the-test-suite`, added by the now-merged #15)