### PR TITLE
fix(start.sh): forward GH_TOKEN into container environment

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -84,6 +84,11 @@ MOUNT_ARGS=(
     "--mount" "type=bind,source=${PROJECT_DIR},target=/workspace"
 )
 
+ENV_ARGS=()
+if [ -n "${GH_TOKEN:-}" ]; then
+    ENV_ARGS+=("-e" "GH_TOKEN")
+fi
+
 if [ -d "$GLOBAL_BASE" ]; then
     MOUNT_ARGS+=(
         "--mount" "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly"
@@ -101,6 +106,7 @@ docker run \
     -it \
     --name "claude-$(basename "$PROJECT_DIR")-$(date +%s)" \
     "${MOUNT_ARGS[@]}" \
+    "${ENV_ARGS[@]}" \
     --network claude-net \
     --memory="2g" \
     --cpus="2" \


### PR DESCRIPTION
## Summary
- docker run wasn't passing through host environment variables, so exporting GH_TOKEN before running start.sh had no effect inside the sandbox
- Forward GH_TOKEN via -e when set on the host, without overriding it with an empty value when unset

## Test plan
- [x] bash -n start.sh
- [x] export GH_TOKEN=stub_token && ./start.sh <dir> base, then echo $GH_TOKEN inside the session