### PR TITLE
feat: wire Squid network egress proxy into build.sh and start.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@
 #   ./build.sh crypto           — build claude-base then claude-crypto
 #   ./build.sh systems          — build claude-base then claude-systems
 #   ./build.sh research         — build claude-base then claude-research
+#   ./build.sh squid            — build only claude-squid (no base dependency)
 #   ./build.sh --no-cache       — build all images, bypassing Docker layer cache
 #   ./build.sh base --no-cache  — build only claude-base, bypassing cache
 #
@@ -49,15 +50,24 @@ build_research() {
     docker build $UID_ARG $NO_CACHE -t claude-research ./research/
 }
 
+# No $UID_ARG — the Squid image creates no claude-agent-equivalent user tied
+# to the host UID; it has no bind-mounted /workspace and nothing that needs
+# host-UID alignment.
+build_squid() {
+    echo "→ Building claude-squid..."
+    docker build $NO_CACHE -t claude-squid ./squid/
+}
+
 case "$TARGET" in
     all)
         build_base
         build_crypto
         build_systems
         build_research
+        build_squid
         echo ""
         echo "All images built:"
-        docker images | grep -E "^claude-(base|crypto|systems|research)\s"
+        docker images | grep -E "^claude-(base|crypto|systems|research|squid)\s"
         ;;
     base)
         build_base
@@ -74,9 +84,12 @@ case "$TARGET" in
         build_base
         build_research
         ;;
+    squid)
+        build_squid
+        ;;
     *)
         echo "Unknown target: $TARGET"
-        echo "Usage: $0 [all|base|crypto|systems|research]"
+        echo "Usage: $0 [all|base|crypto|systems|research|squid]"
         exit 1
         ;;
 esac

--- a/docs/claude_code_security_plan.md
+++ b/docs/claude_code_security_plan.md
@@ -874,3 +874,45 @@ upgrade silently breaks addons compiled against the prior ABI. Neither failure p
 
 No other STRIDE categories are affected. No new privilege, no new mount, no execution of
 workspace-resident code.
+
+---
+
+### Change 15 — Squid Network Egress Proxy Actually Implemented
+**Affects:** Phase 2.8–2.9, §5 (STRIDE Coverage Map, delta only). Date: 2026-08-04.
+
+**What changed:**
+Phase 2.9 and the companion *Squid Proxy Implementation Guide* described a Squid-based
+network egress allowlist, but neither `squid/Dockerfile` nor `squid/squid.conf` was ever
+committed to the sandbox repository, and `start.sh` had no proxy lifecycle, no
+`HTTP_PROXY`/`HTTPS_PROXY` injection, and no reference to Squid at all — Layer 4 of the
+five-layer defense described in §3 was a no-op against the tracked tree. This was closed:
+`squid/` is now committed, `build.sh` builds `claude-squid` as a new target, and `start.sh`
+starts the proxy before the main container, injects the proxy environment variables into it,
+and guarantees teardown via `trap ... EXIT` regardless of how the session ends. Full design
+and rationale: `docs/designs/squid-proxy-integration.md`.
+
+Two hardening decisions beyond what Phase 2.8–2.9 originally specified:
+
+- **Fail-closed proxy startup.** If `claude-squid` fails to start, the session aborts rather
+  than falling back to unrestricted egress. A control that silently degrades to absent on its
+  own failure is the anti-pattern this plan has consistently avoided elsewhere (see Change 12).
+- **Non-root, capability-dropped proxy container.** The proxy runs as the `proxy` system
+  account (uid/gid 13, a standard Debian `base-passwd` account) rather than root, with
+  `--cap-drop=ALL`/`--security-opt=no-new-privileges` on its own invocation — consistent with
+  the treatment already given to every other container in this architecture.
+
+**Why:** Surfaced by `test_squid_isolation.bats` (Group 3, S-1–S-3) failing at `setup_file()`
+because the files it depends on did not exist in the tracked tree. Network egress allowlisting
+is named in §3 and Phase 2.8 as the primary control against Information Disclosure via
+exfiltration; until this change, that control was documentation only.
+
+**STRIDE mapping (delta only):**
+
+| Threat (STRIDE) | Control added |
+|---|---|
+| **Information Disclosure (I)** | Squid allowlist actually built, wired into `build.sh`/`start.sh`, and enforced via `HTTP_PROXY`/`HTTPS_PROXY` injection — previously documented but not present in the tracked tree. Residual, accepted risk: any allowlisted domain remains a potential blind exfiltration channel, since Squid sees only the CONNECT tunnel for HTTPS, not its contents. |
+| **Repudiation (R)** | Squid access log (`access_log stdio:/dev/stdout combined`) actually active and captured by Docker's default log driver, joining the Docker and Claude Code session logs named in Phase 5. |
+| **Elevation of Privilege (E)** | Non-root execution inside the proxy container; `--cap-drop=ALL`/`--security-opt=no-new-privileges` on the proxy's own runtime invocation. Not present in the original guide. |
+| **Denial of Service (D)** | Fail-closed proxy startup is a deliberate, bounded availability cost accepted in exchange for not silently degrading the egress control on proxy failure. |
+
+No other STRIDE category in §5 changes as a result of this work.

--- a/docs/designs/squid-proxy-integration.md
+++ b/docs/designs/squid-proxy-integration.md
@@ -276,6 +276,11 @@ that remains explicitly out of scope per §1.2.
 
 http_port 3128
 
+# Docker tracks this container's process directly; no PID file is needed,
+# and /run/squid.pid is not writable by the non-root "proxy" user (see
+# §6.4, §9 — confirmed empirically during smoke testing, not assumed).
+pid_filename none
+
 # ── Core tier — required for basic toolchain operation ────────────────
 acl allowed_domains dstdomain api.anthropic.com
 acl allowed_domains dstdomain registry.npmjs.org
@@ -317,7 +322,10 @@ http_access allow allowed_domains
 http_access deny all
 
 # ── Logging ─────────────────────────────────────────────────────────
-access_log stdio:/dev/stdout combined
+# "squid" (native format, e.g. TCP_TUNNEL/200) — not "combined" (NCSA
+# format, e.g. TCP_TUNNEL:HIER_DIRECT). Confirmed empirically after a
+# bats S-1/S-3 failure traced to this exact format mismatch.
+access_log stdio:/dev/stdout squid
 
 # ── Privacy and cache ───────────────────────────────────────────────
 cache deny all
@@ -617,10 +625,15 @@ not addressed here, to avoid silent scope expansion beyond what this design set 
 **Q: Does the non-root proxy hardening (§6.4) risk breaking anything Squid needs write access
 to?**
 
-Believed no — caching is disabled (`cache deny all`), logging goes to stdout (no file write),
-and the only file the process needs to read is `/etc/squid/squid.conf` (world-readable by
-default from `COPY`). Should be confirmed empirically at implementation time (step 1 of §8)
-rather than assumed.
+Confirmed yes, during step 5 smoke testing — resolved, not merely assumed safe as originally
+written here. Squid fatally failed to start: `FATAL: failed to open /run/squid.pid: (13)
+Permission denied`. `/run/squid.pid` is root-owned inside the container; Squid's normal pattern
+of opening privileged paths as root before dropping to its effective user doesn't apply here,
+since `USER proxy` makes the process non-root from its very first instruction. Caching
+(`cache deny all`) and logging (`access_log stdio:/dev/stdout`) were correctly identified as
+non-issues — the PID file was the actual gap. Fixed by adding `pid_filename none` to
+`squid.conf` (§5.2): Docker already tracks the container's process directly via its own PID 1
+mechanism, so Squid's own PID file serves no purpose in this setup.
 
 ---
 
@@ -639,3 +652,24 @@ on the proxy container).
 Operator signed off on the §6.3 fail-closed decision. Status moved from Draft to Accepted.
 Document relocated to `docs/designs/squid-proxy-integration.md` per the location convention in
 `docs/designs/docs-as-code-workflow.md` (§2.2, repository layout).
+
+### Version 1.2 — 2026-08-05
+Step 5 smoke testing surfaced a fatal startup failure: `USER proxy` (§5.1) left Squid unable to
+write `/run/squid.pid`, since the non-root process never has the root privileges needed to open
+that root-owned path (contrast with the normal Squid pattern of opening privileged resources as
+root, then dropping privileges). This resolves the §9 open question — the non-root hardening did
+break something, just not caching or logging as originally speculated. Fixed by adding
+`pid_filename none` to `squid/squid.conf` (§5.2); Docker's own process tracking makes Squid's PID
+file unnecessary here. `USER proxy` itself is retained — the fix removes the one thing that
+non-root execution couldn't do, rather than reverting the hardening.
+
+### Version 1.3 — 2026-08-05
+Step 6 (`test_squid_isolation.bats`) failed S-1 and S-3 against a proxy confirmed fully
+functional by manual testing — a complete CONNECT tunnel, TLS handshake, and correct HTTP
+response from `api.anthropic.com`. Root cause: `access_log stdio:/dev/stdout combined` (§5.2)
+uses Squid's NCSA-style `combined` format (`TCP_TUNNEL:HIER_DIRECT`), not the native `squid`
+format (`TCP_TUNNEL/200`) that both Part 4 of `docs/squid_proxy_guide.md` and the bats
+assertions assume — an inconsistency present in the guide since its first version, invisible
+without comparing an actual emitted log line against the documented example. S-2 passed
+regardless, on a substring match loose enough to survive either format. Fixed by changing the
+directive to `access_log stdio:/dev/stdout squid`.

--- a/docs/designs/squid-proxy-integration.md
+++ b/docs/designs/squid-proxy-integration.md
@@ -283,6 +283,10 @@ pid_filename none
 
 # ── Core tier — required for basic toolchain operation ────────────────
 acl allowed_domains dstdomain api.anthropic.com
+# Claude Code's own service endpoint — distinct from api.anthropic.com.
+# Confirmed required by a live 403 denial during a real session; the
+# original guide's allowlist only ever listed api.anthropic.com.
+acl allowed_domains dstdomain platform.claude.com
 acl allowed_domains dstdomain registry.npmjs.org
 acl allowed_domains dstdomain pypi.org
 acl allowed_domains dstdomain files.pythonhosted.org
@@ -673,3 +677,10 @@ assertions assume — an inconsistency present in the guide since its first vers
 without comparing an actual emitted log line against the documented example. S-2 passed
 regardless, on a substring match loose enough to survive either format. Fixed by changing the
 directive to `access_log stdio:/dev/stdout squid`.
+
+### Version 1.4 — 2026-08-06
+A real Claude Code session through the (now-working) proxy failed with `Failed to connect to
+platform.claude.com: Status 403` — Squid correctly denying a domain absent from the allowlist.
+`platform.claude.com` (Claude Code's own service endpoint, distinct from `api.anthropic.com`)
+is now added to the core tier (§5.2). Confirmed required by a live denial rather than
+anticipated in advance; `api.anthropic.com` is retained.

--- a/docs/designs/squid-proxy-integration.md
+++ b/docs/designs/squid-proxy-integration.md
@@ -1,0 +1,641 @@
+# Squid Proxy Integration — Software Design Document
+
+> **Document type:** Software Design Document (SDD)
+> **Status:** Accepted
+> **Relates to:** `docs/claude_code_security_plan.md` (Phase 2.8–2.9, Phase 5 Audit Logging,
+> STRIDE coverage map), `docs/squid_proxy_guide.md` (source guide this design implements and
+> corrects), `ARCHITECTURE.md`, `docs/designs/docs-as-code-workflow.md` (Case E trigger),
+> `docs/designs/claude-sandbox-testing-module-sdd.md` (Test Group 3, S-1–S-3 — currently unable
+> to run; this design is the prerequisite)
+> **Audience:** The engineer maintaining this sandbox — assumes familiarity with the image
+> hierarchy, the entrypoint/global-layer mechanism, and the STRIDE framework used throughout
+> this project's documentation.
+> **Trigger:** Two gaps identified while investigating `test_squid_isolation.bats` setup
+> failures: (1) `squid/Dockerfile` and `squid/squid.conf` are described in
+> `docs/squid_proxy_guide.md` but were never committed to the repository; (2) the tracked
+> `start.sh` contains no proxy lifecycle, no `HTTP_PROXY`/`HTTPS_PROXY` injection, and no
+> reference to Squid at all — contradicting the guide's own claim that "the current `start.sh`
+> already incorporates Squid." Layer 4 of the five-layer defense (network egress allowlisting)
+> is currently a no-op against the tracked tree.
+
+---
+
+## 1. Purpose and Scope
+
+This document designs the actual implementation of Squid-based network egress enforcement for
+`claude-sandbox` — closing the gap between what `docs/squid_proxy_guide.md` describes and what
+is committed and wired into `build.sh`/`start.sh`.
+
+### 1.1 What currently exists vs. what is claimed
+
+| Claimed by `squid_proxy_guide.md` | Actually true of the tracked tree |
+|---|---|
+| `squid/Dockerfile`, `squid/squid.conf` exist under `~/.claude-sandbox/squid/` | Neither file is tracked anywhere in the repo |
+| "The Squid image is built by `build.sh` alongside the Claude Code images" | `build.sh` builds only `base`/`crypto`/`systems`/`research` |
+| "The current `start.sh` already incorporates Squid" (Part 3, Step 4) | Tracked `start.sh` has no proxy container logic, no `HTTP_PROXY`/`HTTPS_PROXY` injection, and runs the target image with direct, unrestricted network access to `claude-net` |
+
+The second row is the one worth sitting with: **this is not a documentation gap alone.** The
+primary control against Information Disclosure via exfiltration — the one Phase 2.8–2.9 of the
+security plan and the STRIDE coverage map both name as the mitigation for that threat — is not
+deployed. Any session started from this repo today has outbound network access constrained only
+by `permissions.deny`'s specific bash-command denials (`curl`, `wget`, `nc`, `ssh`, `scp`), which
+does not cover in-language HTTP clients, `npm install` reaching an unexpected registry, or `git
+clone` to an unexpected remote.
+
+### 1.2 Scope of this document
+
+This document covers:
+
+- `squid/Dockerfile` and `squid/squid.conf`, committed and tracked
+- Additions to `build.sh` to build the Squid image
+- Additions to `start.sh` for proxy container lifecycle: startup, `HTTP_PROXY`/`HTTPS_PROXY`/
+  `NO_PROXY` injection, and guaranteed teardown via `trap ... EXIT`
+- The allowlist design: `dstdomain` as the primary mechanism, `dstdom_regex` as a narrowly
+  scoped exception, and a curated reference-documentation tier
+- Corrections to `docs/squid_proxy_guide.md` Part 3 Step 4 and Part 5 to match what is actually
+  implemented
+- Two hardening additions beyond the original guide: non-root execution inside the proxy
+  container, and runtime hardening flags (`--cap-drop=ALL`, `--security-opt=no-new-privileges`)
+  applied to the proxy container's own `docker run` invocation
+- The fail-open vs. fail-closed decision for proxy startup failure
+
+This document does **not** cover:
+
+- TLS interception / `ssl_bump` (rejected — see §3, Design Principles)
+- Per-profile `squid.conf` variants (explicitly deferred; single shared config for now)
+- Validating the companion-container networking pattern under rootless Podman's `slirp4netns`
+  (deferred to the Podman migration SDD; this design is the Docker-validated baseline it will
+  migrate against)
+- The config-file evaluation question (`docs/claude-sandbox-memory.md`, pre-merge task 3;
+  explicitly deferred until after the Podman migration)
+- Digest-pinning the base images of `base/crypto/systems/research` Dockerfiles (existing,
+  separately tracked ADR-mandate gap; out of scope to expand here — see §5.1 for how this
+  design treats *its own new* `FROM` line)
+
+---
+
+## 2. Context
+
+### 2.1 Why this blocks other work, not just itself
+
+`test_squid_isolation.bats` (Group 3, S-1–S-3) is already written against this exact design —
+it builds `squid/Dockerfile`, runs it as a sibling container on `claude-net`, and asserts on the
+access log. It currently fails at `setup_file()` with an explicit, named error rather than
+skipping silently, per the testing SDD's own error-handling philosophy (§8: "a skipped security
+test is indistinguishable from a passing one"). Group 3 is also the one test group most directly
+relevant to validating the Podman migration's most uncertain change — the companion-container
+networking pattern under `slirp4netns`. Migrating before this exists means migrating the
+highest-risk-of-behavioral-change control with zero regression coverage for it.
+
+### 2.2 CONNECT-tunnel visibility constrains the design space
+
+Squid here does not perform TLS interception. For HTTPS, Squid sees only the `CONNECT
+domain:port` request line — not the path, query string, or body. This rules out `url_regex`
+entirely (it matches full URLs, which Squid never observes for HTTPS traffic under this design)
+and means every policy decision in this document operates at **domain granularity only**. This
+constraint, not stylistic preference, is why `dstdomain`/`dstdom_regex` are the only viable
+mechanisms — see §3.
+
+---
+
+## 3. Design Principles
+
+**`dstdomain` (exact-match) as the default and primary mechanism.** A flat list is scannable in
+seconds during review; a page of regex requires mentally executing each pattern against edge
+cases. The failure mode also differs in the direction that matters: a missing list entry fails
+loudly (connection denied, add the domain), while an unanchored or overly broad regex fails
+silently-permissive — the same class of bug as `squid_proxy_guide.md`'s own Change 2 (a syntax
+error that silently dropped `--cap-drop=ALL`), just at the policy layer instead of the shell
+layer.
+
+**`dstdom_regex` reserved for individually-justified, anchored exceptions.** Not a parallel
+default mechanism. Each use requires an inline comment stating what it covers and why a flat
+list is insufficient (e.g., a package registry's rotating CDN-edge subdomain). Anchored
+(`^...$`) without exception.
+
+**Single shared `squid.conf`, not per-profile variants.** `claude-net` is already a single
+shared network across all profiles; splitting the allowlist per profile now would require
+teaching `start.sh` to select a config variant, which is exactly the kind of config-surface
+decision `docs/claude-sandbox-memory.md`'s pre-merge task 3 defers until after the Podman
+migration. Per-profile splitting is named here as a deliberate future option, not built
+preemptively.
+
+**Blind-tunnel exfiltration is an accepted, pre-existing limitation — not something this design
+claims to solve.** Any domain on the allowlist is a potential blind exfiltration channel: Squid
+restricts *destination*, not *content*, and cannot see inside a permitted HTTPS tunnel. This is
+already true today for `api.anthropic.com`; it does not change in kind as the allowlist grows,
+only in the number of viable channels. Documented explicitly in §6 rather than left implicit.
+
+**Reference-tier curation: authoritative, low-user-generated-content sources only.** Official
+project documentation, not Q&A/forum sites. Two independent reasons, not one: (a) a Q&A site is
+a *larger* plausible-looking blind-exfil channel than an official docs domain, and (b) unmoderated
+third-party text is prompt-injection surface — `docs/claude_code_security_plan.md` Phase 6
+already flags exactly this risk category for any externally-sourced content a session reads.
+
+**Unanticipated mid-session access needs are handled procedurally, not by loosening default
+policy.** `squid_proxy_guide.md` Part 5 already documents the mechanism: edit `squid.conf`,
+rebuild only the Squid image (`squid/` has no toolchain — a Debian+Squid rebuild is seconds), and
+restart only the proxy. Formalized here as a named operational habit (§7.4), not solved by
+widening the default allowlist under time pressure.
+
+**TLS interception (`ssl_bump`) is explicitly rejected.** It would give path-level policy, but
+at the cost of provisioning a MITM CA into every container — new key material to protect,
+breakage for any tool doing certificate pinning, and a direct contradiction of this project's own
+"physical absence over permission checks" and "no secrets on disk in the container" principles.
+Scope explosion relative to the problem it solves.
+
+**Proxy container lifecycle is ephemeral and 1:1 with the session, not a shared long-running
+service.** Matches `squid_proxy_guide.md`'s own reference `start.sh` implementation (per-session
+unique naming) and extends this project's existing "one project, one container, one session"
+operational habit to the proxy. Considered alternative: a single long-running proxy shared across
+concurrent sessions, which would reduce container-startup overhead slightly but adds a
+lingering-container cleanup surface that per-session `trap`-based teardown avoids entirely, and
+diverges from the guide's already-written reference implementation for no clear gain.
+
+---
+
+## 4. Architecture Overview
+
+### 4.1 Current architecture (as tracked, corrected description)
+
+```
+HOST
+├── build.sh          — builds base/crypto/systems/research only
+├── start.sh           — runs the target image directly:
+│                         no proxy, no HTTP_PROXY/HTTPS_PROXY, no egress restriction
+└── (no squid/ directory exists)
+
+CONTAINER (per session)
+    --network claude-net    ← unrestricted egress to anything claude-net's
+                               bridge can route to; permissions.deny is the
+                               only active constraint, and it is narrow
+                               (specific bash commands only)
+```
+
+### 4.2 Target architecture
+
+```
+HOST
+├── build.sh                  ← modified: adds build_squid
+├── start.sh                  ← modified: proxy lifecycle + trap EXIT
+├── squid/                    ← new, tracked
+│   ├── Dockerfile
+│   └── squid.conf
+├── base/ crypto/ systems/ research/   ← unchanged
+└── docs/squid_proxy_guide.md ← corrected: Part 3 Step 4, Part 5
+
+CONTAINER (per session)
+    ┌────────────────────────────┐   ┌──────────────────────────────┐
+    │  claude-<profile>          │   │  claude-proxy-$$              │
+    │  (main session container)  │──▶│  (ephemeral, per-session)     │
+    │  HTTP_PROXY=claude-proxy-$$:3128│  claude-net only               │
+    │  HTTPS_PROXY=...            │   │  non-root, cap-dropped        │
+    └────────────────────────────┘   │  dstdomain allowlist          │
+              │                       │  access_log → stdout          │
+              └── claude-net ─────────┘
+                        │
+                        ▼
+                  THE INTERNET
+                  ✓ core tier (Anthropic API, registries, GitHub)
+                  ✓ reference tier (per-profile docs)
+                  ✗ everything else
+```
+
+### 4.3 Data flow at session start
+
+```
+start.sh invoked
+    │
+    ├─ existing preflight checks (docker daemon, project dir, image tag, claude-net)
+    ├─ NEW: check claude-squid image exists
+    │        └─ missing → error, "Build it first with: ./build.sh squid", exit 1
+    ├─ NEW: trap cleanup EXIT registered
+    ├─ NEW: start proxy container (detached, unique name claude-proxy-$$)
+    │        └─ fails to start → fail-closed (§6.3): abort, main container never starts
+    ├─ start main session container
+    │        --env HTTP_PROXY="http://claude-proxy-$$:3128"
+    │        --env HTTPS_PROXY="http://claude-proxy-$$:3128"
+    │        --env NO_PROXY="localhost,127.0.0.1"
+    │        (existing mounts, --cap-drop=ALL, --security-opt=no-new-privileges unchanged)
+    │
+    ▼
+session runs; all outbound HTTP/HTTPS from the main container is forced through the proxy
+    │
+    ▼
+session ends (normal exit, error, or Ctrl+C)
+    │
+    └─ trap fires: stop + remove claude-proxy-$$ unconditionally
+```
+
+---
+
+## 5. Component Design
+
+### 5.1 `squid/Dockerfile`
+
+Carries forward the guide's existing design (`debian:bookworm-slim`, matching the base image
+family used everywhere else in this project; `-N` foreground flag required so Docker's PID 1
+tracking works correctly) with two additions not present in the original guide:
+
+```dockerfile
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends squid \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY squid.conf /etc/squid/squid.conf
+
+EXPOSE 3128
+
+# Non-root execution (addition beyond the original guide — see SDD §6.4).
+# Debian's squid package creates a service user for this purpose; confirm the
+# exact name (expected: "proxy") via `id proxy` inside a built image before
+# finalizing — do not assume without checking against the actual package.
+USER proxy
+
+CMD ["squid", "-N", "-f", "/etc/squid/squid.conf"]
+```
+
+**Digest pinning.** This is a *new* file, not an edit to an existing one, so the existing
+repo-wide digest-pinning gap (tracked separately, deferred to the Podman migration where every
+`FROM` line is already being touched) does not automatically extend to it by inertia. Recommend
+pinning `FROM debian:bookworm-slim@sha256:<digest>` from the start — resolve the current digest
+at implementation time (`docker pull debian:bookworm-slim && docker inspect --format='{{index
+.RepoDigests 0}}' debian:bookworm-slim`) rather than carrying a fabricated or stale value into
+this document. Not extending this to `base/crypto/systems/research`'s existing `FROM` lines —
+that remains explicitly out of scope per §1.2.
+
+### 5.2 `squid/squid.conf`
+
+```
+# ─── squid.conf ──────────────────────────────────────────────────────
+# Default-deny outbound policy. dstdomain (exact match) is the primary
+# mechanism; dstdom_regex is used only for the individually-justified
+# exception below, anchored, with its own comment.
+# ─────────────────────────────────────────────────────────────────────
+
+http_port 3128
+
+# ── Core tier — required for basic toolchain operation ────────────────
+acl allowed_domains dstdomain api.anthropic.com
+acl allowed_domains dstdomain registry.npmjs.org
+acl allowed_domains dstdomain pypi.org
+acl allowed_domains dstdomain files.pythonhosted.org
+acl allowed_domains dstdomain github.com
+acl allowed_domains dstdomain api.github.com
+acl allowed_domains dstdomain codeload.github.com
+acl allowed_domains dstdomain raw.githubusercontent.com
+
+# ── Reference tier — authoritative, low-UGC documentation only ────────
+# Curated per SDD §3. Stack Overflow and similar UGC sites are
+# deliberately excluded — see squid-proxy-integration.md §3.
+acl allowed_domains dstdomain docs.python.org
+acl allowed_domains dstdomain nodejs.org
+acl allowed_domains dstdomain developer.mozilla.org
+
+# systems profile
+acl allowed_domains dstdomain en.cppreference.com
+acl allowed_domains dstdomain cmake.org
+
+# crypto profile
+acl allowed_domains dstdomain www.openssl.org
+
+# research profile
+acl allowed_domains dstdomain ctan.org
+acl allowed_domains dstdomain tug.org
+
+# ── dstdom_regex exceptions (none at initial implementation) ──────────
+# Reserved for individually-justified, anchored patterns only — e.g. a
+# registry's rotating CDN-edge subdomain that a flat list can't track.
+# Example (commented, not active):
+# acl allowed_domains dstdom_regex ^[a-z0-9-]+\.pkg-cdn\.example\.com$
+
+# ── Access policy ───────────────────────────────────────────────────
+acl CONNECT method CONNECT
+http_access allow CONNECT allowed_domains
+http_access allow allowed_domains
+http_access deny all
+
+# ── Logging ─────────────────────────────────────────────────────────
+access_log stdio:/dev/stdout combined
+
+# ── Privacy and cache ───────────────────────────────────────────────
+cache deny all
+forwarded_for off
+via off
+```
+
+Single shared file for all profiles, per §3 — a `systems` session and a `research` session both
+get the full reference tier rather than a profile-scoped subset. This is a deliberate simplicity
+trade-off (§3); profile-scoping is future work if the shared list proves too broad in practice.
+
+### 5.3 `build.sh` additions
+
+```bash
+build_squid() {
+    echo "→ Building claude-squid..."
+    docker build $NO_CACHE -t claude-squid ./squid/
+}
+```
+
+Deliberately **no `$UID_ARG`** — unlike `base`/`crypto`/`systems`/`research`, the Squid image
+creates no `claude-agent`-equivalent user tied to the host UID; it has no bind-mounted
+`/workspace` and nothing that needs host-UID alignment. This is a documented omission, not an
+oversight, to preempt the "why doesn't this build call match the others" question later.
+
+Add to the `case "$TARGET"` dispatch:
+
+```bash
+    squid)
+        build_squid
+        ;;
+```
+
+And add `build_squid` to the `all` target alongside the four existing builds.
+
+### 5.4 `start.sh` modifications
+
+```bash
+# Preflight: Squid image must exist (fail-closed if missing, matching the
+# existing pattern for base/crypto/systems/research image checks)
+if ! docker image inspect claude-squid > /dev/null 2>&1; then
+    echo "Error: image 'claude-squid' does not exist."
+    echo "Build it first with: ./build.sh squid"
+    exit 1
+fi
+
+PROXY_NAME="claude-proxy-$$"
+
+# Guaranteed teardown regardless of how the script exits (normal completion,
+# main-container failure, or Ctrl+C) — a plain "stop after" line only runs
+# on the clean-exit path and would leak the proxy container otherwise.
+cleanup() {
+    local exit_code=$?
+    if docker ps -a --format '{{.Names}}' | grep -qx "$PROXY_NAME"; then
+        docker stop "$PROXY_NAME" > /dev/null 2>&1 || true
+        docker rm "$PROXY_NAME" > /dev/null 2>&1 || true
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+echo "Starting Squid proxy ($PROXY_NAME)..."
+if ! docker run -d \
+    --name "$PROXY_NAME" \
+    --network claude-net \
+    --cap-drop=ALL \
+    --security-opt=no-new-privileges \
+    claude-squid > /dev/null; then
+    echo "Error: Squid proxy failed to start."
+    echo "Fail-closed per squid-proxy-integration.md SDD §6.3 — aborting session."
+    exit 1
+fi
+```
+
+The existing `docker run` for the main container gains three env vars, no other changes:
+
+```bash
+    --env HTTP_PROXY="http://$PROXY_NAME:3128" \
+    --env HTTPS_PROXY="http://$PROXY_NAME:3128" \
+    --env NO_PROXY="localhost,127.0.0.1" \
+```
+
+`--cap-drop=ALL`/`--security-opt=no-new-privileges` on the proxy container's own invocation are
+an addition beyond the original guide — see §6.4.
+
+### 5.5 `docs/squid_proxy_guide.md` corrections
+
+- Part 3, Step 4: replace the stale reference `start.sh` sample (which also predates the
+  global-layer-injection mount logic, a second, independent staleness) with a pointer to the
+  actual tracked `start.sh`.
+- Part 5, Maintenance: "restart the proxy container" no longer applies as a manual step — the
+  proxy is created fresh per session (§3), so a `squid.conf` edit + image rebuild is picked up
+  automatically by the *next* `start.sh` invocation. Simplifies the documented procedure.
+
+---
+
+## 6. Threat Model
+
+### 6.1 New surfaces
+
+| Surface | Description |
+|---|---|
+| `squid/Dockerfile`, `squid/squid.conf` (host, tracked) | Baked into the image at build time; not runtime-injected |
+| `claude-squid` image | Built by `build.sh squid` |
+| Proxy container (ephemeral, per-session) | Runs on `claude-net`, non-root, cap-dropped |
+| `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` env vars | Injected into the main container only |
+| Squid access log | stdout → Docker's default `json-file` driver |
+
+### 6.2 STRIDE analysis
+
+**Spoofing (S).** Docker's internal DNS resolves `claude-proxy-$$` uniquely per session (shell
+PID); concurrent sessions have distinct names by construction. Residual, pre-existing structural
+point (not introduced by this design): `claude-net` is a flat bridge network with no additional
+segmentation, so any container on it can in principle address any other container on it by name
+or IP. This predates this design — worth noting for completeness, not a new gap.
+
+**Tampering (T).** `squid.conf` is baked into the image at build time, not mounted at runtime —
+the main session container has no path to modify it, since the host `squid/` directory is never
+bind-mounted into any session container. A compromised session has no `docker` socket access and
+cannot exec into or otherwise modify the proxy container.
+
+**Repudiation (R).** Primary positive contribution of this design as a whole. `access_log
+stdio:/dev/stdout combined` is captured by Docker's default `json-file` log driver (proxy
+container is not currently given explicit `--log-opt` size caps in this design — Docker's
+default has no size limit; adding `--log-opt max-size=10m --log-opt max-file=3` is a cheap
+hygiene addition worth including at implementation time, though it is not filling a functional
+gap — logs are captured either way). Note, found in passing: the tracked `start.sh` does not
+currently pass `--log-driver json-file --log-opt ...` to the *main* session container either,
+despite `docs/claude_code_security_plan.md` Phase 5 documenting this as standard practice. This
+is a separate, pre-existing gap, orthogonal to Squid — flagged here per the same "no silent
+scope expansion" principle the original issue report itself applied, not fixed as part of this
+change.
+
+**Information Disclosure (I).** This is the gap this design closes: default-deny egress,
+allowlist-only reachability. Residual, explicitly accepted (§3): any allowlisted domain is a
+potential blind exfiltration channel, since CONNECT-tunnel proxying gives Squid no visibility
+into tunnel contents. This scales with allowlist size — a incremental, not qualitative, change
+introduced by adding the reference tier.
+
+**Denial of Service (D).** See §6.3 — the fail-open/fail-closed decision is the primary DoS
+trade-off in this design.
+
+**Elevation of Privilege (E).** See §6.4 — non-root execution inside the proxy container is a
+hardening addition beyond the original guide.
+
+### 6.3 Decision record: fail-open vs. fail-closed
+
+Two options for proxy-container-fails-to-start:
+
+- **Fail-open:** proceed without the proxy; main container starts with unrestricted network
+  access.
+- **Fail-closed:** abort; main container never starts.
+
+**Decision: fail-closed** (implemented in §5.4 above; signed off by the operator 2026-08-03 —
+see Changelog).
+
+Rationale: fail-open would silently recreate the exact gap this design exists to close — and
+arguably worse than today's state, since once this SDD ships, the operator has reasonable cause
+to believe egress protection is active. A security control that silently degrades to absent on
+its own failure is the anti-pattern this project has consistently avoided elsewhere (e.g., the
+Squid guide's own Change 2 regression is precisely a case of a control silently failing to
+apply). The availability cost is real but bounded: `claude-squid` is a small, dependency-light
+image (Debian + Squid, no toolchain), so build failures should be rare and fast to diagnose and
+fix — unlike, say, a broken `claude-systems` build blocking one profile, a broken proxy build
+blocks all sessions, which is a meaningful but not disproportionate cost given what it protects.
+
+This differs from the warn-only precedent set in `interpreter-presence-health-check.md` and
+`workspace-artifact-staleness.md` — those checks address environment-correctness conditions
+(a stale venv, a stale CMake cache) where hard-failing would impose an availability cost
+disproportionate to a non-security-relevant problem. Network egress enforcement is the primary
+control against Information Disclosure; the asymmetry does not hold here.
+
+### 6.4 Decision record: non-root execution and runtime hardening for the proxy container
+
+Not present in the original `squid_proxy_guide.md`. Two related findings from reviewing the
+guide's Dockerfile and reference `start.sh` against this project's own stated principles:
+
+1. The guide's `Dockerfile` has no `USER` directive, and its `squid.conf` does not set
+   `cache_effective_user` (the directive Debian's stock config normally uses to drop privileges
+   internally after startup). Without either, Squid runs as root for its full process lifetime.
+   Port 3128 does not require root to bind (only ports below 1024 do), so there is no functional
+   reason for this. Addressed in §5.1 via `USER proxy` — pending implementation-time
+   confirmation of the exact service-user name Debian's `squid` package creates.
+2. The guide's reference `start.sh` proxy invocation carries no `--cap-drop=ALL` or
+   `--security-opt=no-new-privileges`, inconsistent with the treatment given to the main session
+   container and with this project's "no single control carries the full burden" posture applied
+   everywhere else. Addressed in §5.4.
+
+Neither finding is a currently-exploited gap — the proxy does not execute attacker-influenced
+code in the way the main session container's `claude-agent` process does. The recommendation is
+defense-in-depth consistency: every other container in this project runs non-root and
+capability-dropped; the proxy should not be the one exception, especially given it is a new
+network-facing component sitting directly between every session and the internet.
+
+### 6.5 Updated STRIDE coverage map (delta)
+
+| Threat (STRIDE) | Controls — pre-existing (claimed but not implemented) | Controls — added by this design |
+|---|---|---|
+| **Information Disclosure (I)** | Squid allowlist (documented, not implemented) | Squid allowlist actually built, wired into `build.sh`/`start.sh`, and enforced via `HTTP_PROXY`/`HTTPS_PROXY` injection; fail-closed on proxy startup failure |
+| **Repudiation (R)** | Squid access log (documented, not implemented) | Access log actually active, captured via Docker's default log driver |
+| **Elevation of Privilege (E)** | — | Non-root execution inside the proxy container; `--cap-drop=ALL` / `--security-opt=no-new-privileges` on the proxy's own runtime invocation |
+| **Denial of Service (D)** | — | Fail-closed proxy startup is a deliberate, bounded availability cost accepted in exchange for not silently degrading the egress control (§6.3) |
+
+No other row in the existing coverage map changes.
+
+---
+
+## 7. Interface Contract
+
+### 7.1 `build.sh` contract
+
+- `./build.sh squid` builds `claude-squid` standalone, no dependency on `claude-base`.
+- `./build.sh` (no target / `all`) includes `claude-squid` in the full build.
+- No `HOST_UID` build-arg is passed or required for this target (§5.3).
+
+### 7.2 `start.sh` contract
+
+- Aborts before starting the main container if `claude-squid` does not exist, with the same
+  `Build it first with: ./build.sh squid` guidance pattern used for the other profile images.
+- Aborts (fail-closed) if the proxy container fails to start; the main session container is
+  never started in that case.
+- Proxy container is guaranteed torn down on script exit via `trap ... EXIT`, regardless of exit
+  path (success, main-container failure, or interrupt).
+- Existing positional interface (`start.sh <project_dir> [image]`) is unchanged.
+
+### 7.3 Allowlist contract
+
+- `dstdomain` exact-match is the default and required mechanism for all new entries.
+- `dstdom_regex` requires an inline comment justifying why a flat list is insufficient, and must
+  be anchored.
+- Single `squid.conf`, shared across all profiles (§3) — no profile-scoped subsetting at this
+  stage.
+
+### 7.4 What this design does not guarantee
+
+- Does not protect against exfiltration to any domain already on the allowlist — CONNECT-tunnel
+  blindness is an accepted limitation, not a solved problem (§3, §6.2-I).
+- Does not cover unanticipated third-party sites needed mid-session. The documented path is the
+  break-glass procedure: edit `squid.conf`, rebuild `claude-squid` only (seconds — no toolchain),
+  the next `start.sh` invocation picks it up automatically. This is an operational habit, not a
+  gap to be closed by loosening default policy.
+- Does not validate behavior under rootless Podman/`slirp4netns` — explicitly deferred to the
+  Podman migration SDD, which will use this design (and `test_squid_isolation.bats` against it)
+  as the known-good baseline.
+
+---
+
+## 8. Implementation Plan
+
+Each step maps to a single commit, per project convention.
+
+1. **Add `squid/Dockerfile` and `squid/squid.conf`** — content per §5.1–5.2. Resolve and pin the
+   `debian:bookworm-slim` digest at this step; confirm the Debian-created service-user name via
+   `id proxy` (or actual name found) inside a locally built image before finalizing `USER`.
+2. **Add `build_squid` to `build.sh`** — §5.3, including the `squid` case target and inclusion in
+   `all`.
+3. **Modify `start.sh`** — §5.4: image-existence preflight, `trap cleanup EXIT`, proxy startup
+   with fail-closed behavior, `--env` additions to the main container invocation.
+4. **Correct `docs/squid_proxy_guide.md`** — §5.5: Part 3 Step 4 and Part 5, per the corrections
+   described above. Add a changelog entry to the guide following its own established convention
+   (Change 6).
+5. **Rebuild and smoke test** — `./build.sh squid`, then a manual session start confirming: proxy
+   container starts and is visible in `docker ps`; an allowed-domain request succeeds; a
+   non-allowed-domain request is refused; the proxy container is gone after the session ends
+   (including after a `Ctrl+C` interrupt, to verify the `trap` path specifically, not just clean
+   exit).
+6. **Run `test_squid_isolation.bats`** — `bats --filter-tags slow tests/test_squid_isolation.bats`
+   (or the full slow tier) — S-1/S-2/S-3 should now pass against the real `squid/` directory
+   rather than failing at `setup_file()`.
+7. **Add a changelog entry** to `docs/claude_code_security_plan.md`, following the established
+   Change-N format, using §6 of this document as source material.
+
+---
+
+## 9. Open Questions and Non-Decisions
+
+**Q: Should `squid.conf` be split per-profile now rather than shared?**
+
+Not decided; deliberately deferred per §3. Revisit only if the shared reference tier proves
+too broad for a given profile in practice, or when the config-file evaluation (pre-merge task 3)
+is taken up post-Podman-migration.
+
+**Q: Should the reference tier be expanded preemptively to reduce break-glass frequency?**
+
+Not decided. Current position (§3, §7.4): fixed list at implementation time, expanded via the
+break-glass procedure as real, observed need arises — not by trying to anticipate every future
+documentation site now. If break-glass edits become frequent for the same handful of domains,
+that is itself the signal to promote them into the tracked reference tier.
+
+**Q: Should `--log-opt max-size`/`max-file` be added explicitly to the proxy container, given
+the main container doesn't currently set them either?**
+
+Noted in §6.2-R as a cheap hygiene addition for the proxy specifically, recommended at
+implementation time. The main-container gap is flagged as a separate, pre-existing finding —
+not addressed here, to avoid silent scope expansion beyond what this design set out to fix.
+
+**Q: Does the non-root proxy hardening (§6.4) risk breaking anything Squid needs write access
+to?**
+
+Believed no — caching is disabled (`cache deny all`), logging goes to stdout (no file write),
+and the only file the process needs to read is `/etc/squid/squid.conf` (world-readable by
+default from `COPY`). Should be confirmed empirically at implementation time (step 1 of §8)
+rather than assumed.
+
+---
+
+## Changelog
+
+### Version 1.0 — 2026-08-03
+Initial draft. Derived from the design discussion between the operator and Claude Sonnet 5,
+triggered by `test_squid_isolation.bats` setup failures surfacing that `squid/` was never
+committed and `start.sh` was never actually wired to use it, contradicting
+`docs/squid_proxy_guide.md`'s claims. Establishes `dstdomain`-primary/`dstdom_regex`-exception
+allowlist design, a curated reference-documentation tier, fail-closed proxy startup, and two
+hardening additions beyond the original guide (non-root proxy execution, runtime hardening flags
+on the proxy container).
+
+### Version 1.1 — 2026-08-03
+Operator signed off on the §6.3 fail-closed decision. Status moved from Draft to Accepted.
+Document relocated to `docs/designs/squid-proxy-integration.md` per the location convention in
+`docs/designs/docs-as-code-workflow.md` (§2.2, repository layout).

--- a/docs/squid_proxy_guide.md
+++ b/docs/squid_proxy_guide.md
@@ -215,78 +215,34 @@ docker build -t claude-squid ~/.claude-sandbox/squid/
 
 ---
 
-### Step 4 — Update the main launch script
+### Step 4 — The launch script
 
-The current `start.sh` already incorporates Squid. For reference, the
-core pattern it uses is shown below. The key points are:
+`start.sh`, tracked at the repository root alongside `build.sh`, implements
+the proxy lifecycle described in this guide. Rather than duplicate its
+contents here — where they can silently drift out of sync with the actual
+script, as the previous version of this section did — this section
+summarizes the pattern; read `start.sh` directly for the authoritative
+implementation.
 
-- The proxy container is started first with `-d` (detached) and given a
-  unique name derived from the shell PID (`$$`) so concurrent sessions
-  don't collide.
-- `HTTP_PROXY` and `HTTPS_PROXY` are set to the proxy container's name.
-  Docker's internal DNS resolves container names on the same network, so
-  `http://claude-proxy-$$:3128` reaches the Squid container without any
-  IP address configuration.
-- `NO_PROXY` excludes localhost so that intra-container loopback traffic
-  is not accidentally routed through the proxy.
-- After the Claude session exits, the proxy container is stopped and
-  removed. The `||  true` guard ensures a failed stop doesn't mask the
-  fact that the session completed.
+- A preflight check aborts before the session starts if the `claude-squid`
+  image has not been built (`./build.sh squid`).
+- The proxy container is started first, detached (`-d`), with a name derived
+  from the shell PID (`claude-proxy-$$`) so concurrent sessions don't
+  collide.
+- If the proxy fails to start, the script aborts and the main session
+  container is never started — a fail-closed decision recorded in
+  `docs/designs/squid-proxy-integration.md` §6.3.
+- `HTTP_PROXY` and `HTTPS_PROXY` are injected into the main container as
+  `http://claude-proxy-$$:3128`. Docker's internal DNS resolves the proxy
+  container's name on the same network without any IP configuration.
+  `NO_PROXY` excludes localhost so intra-container loopback traffic isn't
+  routed through the proxy.
+- A `trap ... EXIT` guarantees the proxy container is stopped and removed
+  regardless of how the script exits — normal completion, a failure in the
+  main container, or an interrupt — not just the clean-exit path.
 
-```bash
-#!/usr/bin/env bash
-# Usage: start.sh <project_directory> [image]
-# image: base | crypto | systems | research  (default: base)
-
-set -euo pipefail
-
-PROJECT_DIR="${1:-$(pwd)}"
-PROJECT_DIR="$(realpath "$PROJECT_DIR")"
-IMAGE_TAG="${2:-base}"
-IMAGE_NAME="claude-${IMAGE_TAG}"
-PROXY_NAME="claude-proxy-$$"
-CLAUDE_NAME="claude-$(basename "$PROJECT_DIR")-$$"
-
-echo "Project : $PROJECT_DIR"
-echo "Image   : $IMAGE_NAME"
-echo "Proxy   : $PROXY_NAME"
-echo ""
-
-echo "Starting Squid proxy..."
-docker run -d \
-    --name "$PROXY_NAME" \
-    --network claude-net \
-    claude-squid
-
-echo "Starting Claude Code sandbox..."
-docker run --rm -it \
-    --name "$CLAUDE_NAME" \
-    --network claude-net \
-    --env HTTP_PROXY="http://$PROXY_NAME:3128" \
-    --env HTTPS_PROXY="http://$PROXY_NAME:3128" \
-    --env NO_PROXY="localhost,127.0.0.1" \
-    --env ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
-    --mount type=bind,source="$PROJECT_DIR",target=/workspace \
-    --memory="2g" \
-    --cpus="2" \
-    --security-opt=no-new-privileges \
-    --cap-drop=ALL \
-    --log-driver json-file \
-    --log-opt max-size=50m \
-    --log-opt max-file=5 \
-    "$IMAGE_NAME"
-
-echo ""
-echo "Session ended. Stopping proxy..."
-docker stop "$PROXY_NAME" && docker rm "$PROXY_NAME" || true
-echo "Done."
-```
-
-Make it executable:
-
-```bash
-chmod +x ~/.claude-sandbox/start.sh
-```
+See `docs/designs/squid-proxy-integration.md` for the full design and the
+STRIDE analysis behind these decisions.
 
 ---
 
@@ -346,7 +302,7 @@ Any `TCP_TUNNEL` or `TCP_MISS` to a domain you did not intentionally allow is a 
 
 ## Part 5 — Maintenance
 
-**Adding an allowed domain** for a specific project: edit `squid.conf`, add a line to the `acl allowed_domains` block, rebuild the Squid image, and restart the proxy container. The Claude Code containers do not need to be rebuilt.
+**Adding an allowed domain** for a specific project: edit `squid.conf`, add a line to the `acl allowed_domains` block, and rebuild the Squid image. No manual restart step is needed — the proxy container is ephemeral and recreated fresh on every `start.sh` invocation (see Part 3, Step 4), so the next session picks up the rebuild automatically. The Claude Code containers do not need to be rebuilt.
 
 ```bash
 docker build -t claude-squid ~/.claude-sandbox/squid/
@@ -492,3 +448,37 @@ image-layer expressions of the same per-domain separation of concerns.
 **Why:** The Ubuntu reference was a stale artefact. The added sentence makes
 the relationship between the image hierarchy and the network policy explicit
 so both can be maintained together when a new project type is added.
+
+---
+
+### Change 6 — Squid Actually Implemented and Wired In
+**Affects:** Part 3 Step 4 (launch script), Part 5 (Maintenance). Date: 2026-08-04.
+
+**What changed:**
+`squid/Dockerfile` and `squid/squid.conf` are now committed and tracked in
+the repository — previously this guide described files that did not exist
+anywhere in version control. `build.sh` now builds `claude-squid` via a new
+`squid` target, included in `all`. The tracked `start.sh` now implements the
+proxy lifecycle Step 4 previously only claimed it did: a fail-closed
+preflight check for the `claude-squid` image, `trap`-based teardown of the
+proxy container covering normal exit, main-container failure, and interrupt,
+and `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` injection into the main container.
+Step 4's fabricated reference `start.sh` sample — which also predated the
+global-layer-injection mount logic, a second, independent staleness — is
+replaced with a pointer to the actual tracked script. Part 5's "restart the
+proxy container" instruction is removed: the proxy is ephemeral and
+recreated fresh on every `start.sh` invocation, so a `squid.conf` edit plus
+an image rebuild is picked up automatically by the next session with no
+separate restart step.
+
+**Why:** `test_squid_isolation.bats` (Group 3, S-1–S-3) failed at
+`setup_file()` because `squid/` was never committed — this guide's own claim
+that "the current `start.sh` already incorporates Squid" was false against
+the tracked tree. See `docs/designs/squid-proxy-integration.md` for the full
+design, STRIDE analysis, and rationale (fail-closed startup, non-root proxy
+execution, digest pinning).
+
+**Security posture:** Materially improved, not a documentation-only fix.
+Before this change, Layer 4 (network egress allowlisting) was a no-op:
+sessions ran with unrestricted egress on `claude-net`, constrained only by
+`permissions.deny`'s narrow bash-command denials. This closes that gap.

--- a/docs/squid_proxy_guide.md
+++ b/docs/squid_proxy_guide.md
@@ -153,8 +153,11 @@ http_access deny all
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 
-# Log every request to stdout so Docker captures it
-access_log stdio:/dev/stdout combined
+# Log every request to stdout so Docker captures it. "squid" is Squid's
+# native log format (e.g. TCP_TUNNEL/200) — not "combined", the NCSA/Apache
+# format (e.g. TCP_TUNNEL:HIER_DIRECT), which the result codes in Part 4
+# below assume.
+access_log stdio:/dev/stdout squid
 
 # ── Privacy and cache ─────────────────────────────────────────────────────────
 
@@ -482,3 +485,52 @@ execution, digest pinning).
 Before this change, Layer 4 (network egress allowlisting) was a no-op:
 sessions ran with unrestricted egress on `claude-net`, constrained only by
 `permissions.deny`'s narrow bash-command denials. This closes that gap.
+
+---
+
+### Change 7 — `pid_filename none` Added After Non-Root Startup Failure
+**Affects:** Step 1 (`squid.conf`). Date: 2026-08-05.
+
+**What changed:**
+Smoke testing (per Change 6) found the proxy container exiting immediately after start, with
+`docker logs` showing `FATAL: failed to open /run/squid.pid: (13) Permission denied`. Running
+Squid entirely as the non-root `proxy` user (introduced beyond this guide's original design —
+see `docs/designs/squid-proxy-integration.md` §6.4) means it never holds root privileges to
+open the root-owned `/run/squid.pid`, unlike Squid's normal pattern of opening privileged
+resources as root before dropping to its effective user. `pid_filename none` was added to
+`squid.conf`, telling Squid not to write a PID file at all.
+
+**Why:** Docker already tracks this container's process directly as its PID 1; Squid's own PID
+file serves no purpose in this setup and was the one thing non-root execution from process start
+couldn't do. Caching and logging — the other candidates considered for breakage under non-root
+execution — were unaffected, as expected (caching is disabled via `cache deny all`; the access
+log goes to stdout, not a file).
+
+**Security posture:** Unchanged from Change 6's hardening — `USER proxy` is retained. This
+removes the specific obstacle to non-root execution rather than reverting it.
+
+---
+
+### Change 8 — Access Log Format Corrected from `combined` to `squid`
+**Affects:** Step 1 (`squid.conf`). Date: 2026-08-05.
+
+**What changed:**
+Step 1's `squid.conf` template set `access_log stdio:/dev/stdout combined`. This has been an
+inconsistency in this guide since its first version: `combined` is Squid's NCSA/Apache-style log
+format, whose result field is `%Ss:%Sh` — e.g. `TCP_TUNNEL:HIER_DIRECT` — while Part 4's own
+documented example lines (`TCP_TUNNEL/200`, `TCP_DENIED/403`) are Squid's native `squid` format,
+a different named format entirely. `test_squid_isolation.bats` (S-1, S-3) failed against a fully
+working proxy — full CONNECT tunnel, full TLS handshake, correct 404 from `api.anthropic.com` —
+because the assertions parse the native format's `TAG/CODE` shape, which `combined` never
+produces. S-2 passed regardless, by coincidence: its check is a loose `TCP_DENIED` substring
+match, present in both formats, just followed by `:HIER_NONE` instead of `/403`. The directive
+is now `access_log stdio:/dev/stdout squid`.
+
+**Why:** Nobody had run this configuration end-to-end until step 5 smoke testing surfaced it.
+The mismatch was invisible from reading the config alone — both `combined` and `squid` are valid
+Squid log formats, and only comparing an actual emitted log line against Part 4's documented
+example revealed the discrepancy.
+
+**Security posture:** Unchanged — this is a log-format correctness fix, not a policy change. The
+allowlist enforcement itself (confirmed working via the manual CONNECT tunnel test) was never
+affected.

--- a/docs/squid_proxy_guide.md
+++ b/docs/squid_proxy_guide.md
@@ -128,8 +128,11 @@ http_port 3128
 
 # ── Allowed destinations ──────────────────────────────────────────────────────
 
-# Claude Code API endpoint (required for all Claude Code operation)
+# Claude Code API endpoints (both required for all Claude Code operation —
+# platform.claude.com is Claude Code's own service endpoint, distinct from
+# the classic Anthropic API domain)
 acl allowed_domains dstdomain api.anthropic.com
+acl allowed_domains dstdomain platform.claude.com
 
 # Package registries — add or remove based on your project's needs
 # acl allowed_domains dstdomain registry.npmjs.org
@@ -534,3 +537,22 @@ example revealed the discrepancy.
 **Security posture:** Unchanged — this is a log-format correctness fix, not a policy change. The
 allowlist enforcement itself (confirmed working via the manual CONNECT tunnel test) was never
 affected.
+
+---
+
+### Change 9 — `platform.claude.com` Added to the Core Tier Allowlist
+**Affects:** Step 1 (`squid.conf`). Date: 2026-08-06.
+
+**What changed:**
+A real Claude Code session through the fixed proxy hit `Failed to connect to
+platform.claude.com: Status 403` — Squid correctly denying a domain that was never on the
+allowlist. Step 1's core tier had only ever listed `api.anthropic.com`. `platform.claude.com` —
+Claude Code's own service endpoint, distinct from the classic Anthropic API domain — is now
+also allowed.
+
+**Why:** Confirmed required by a live, session-blocking denial, not by inspecting Claude Code's
+source or documentation in advance. `api.anthropic.com` is retained; nothing so far indicates
+it's unused.
+
+**Security posture:** The allowlist grows by exactly one entry, required for Claude Code to
+function at all. No change to the default-deny posture or any other control.

--- a/squid/Dockerfile
+++ b/squid/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+
+RUN apt-get update && apt-get install -y --no-install-recommends squid \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY squid.conf /etc/squid/squid.conf
+
+EXPOSE 3128
+
+# Non-root execution (addition beyond the original guide — see SDD §6.4).
+# "proxy" (uid/gid 13) is a base-passwd system account present in every
+# Debian install; squid's own postinst defaults cache_effective_user to
+# it. Confirmed against the bookworm squid 5.7-2+deb12u5 package's
+# postinst script, not assumed.
+USER proxy
+
+CMD ["squid", "-N", "-f", "/etc/squid/squid.conf"]

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -1,0 +1,55 @@
+# ─── squid.conf ──────────────────────────────────────────────────────
+# Default-deny outbound policy. dstdomain (exact match) is the primary
+# mechanism; dstdom_regex is used only for the individually-justified
+# exception below, anchored, with its own comment.
+# ─────────────────────────────────────────────────────────────────────
+
+http_port 3128
+
+# ── Core tier — required for basic toolchain operation ────────────────
+acl allowed_domains dstdomain api.anthropic.com
+acl allowed_domains dstdomain registry.npmjs.org
+acl allowed_domains dstdomain pypi.org
+acl allowed_domains dstdomain files.pythonhosted.org
+acl allowed_domains dstdomain github.com
+acl allowed_domains dstdomain api.github.com
+acl allowed_domains dstdomain codeload.github.com
+acl allowed_domains dstdomain raw.githubusercontent.com
+
+# ── Reference tier — authoritative, low-UGC documentation only ────────
+# Curated per SDD §3. Stack Overflow and similar UGC sites are
+# deliberately excluded — see docs/designs/squid-proxy-integration.md §3.
+acl allowed_domains dstdomain docs.python.org
+acl allowed_domains dstdomain nodejs.org
+acl allowed_domains dstdomain developer.mozilla.org
+
+# systems profile
+acl allowed_domains dstdomain en.cppreference.com
+acl allowed_domains dstdomain cmake.org
+
+# crypto profile
+acl allowed_domains dstdomain www.openssl.org
+
+# research profile
+acl allowed_domains dstdomain ctan.org
+acl allowed_domains dstdomain tug.org
+
+# ── dstdom_regex exceptions (none at initial implementation) ──────────
+# Reserved for individually-justified, anchored patterns only — e.g. a
+# registry's rotating CDN-edge subdomain that a flat list can't track.
+# Example (commented, not active):
+# acl allowed_domains dstdom_regex ^[a-z0-9-]+\.pkg-cdn\.example\.com$
+
+# ── Access policy ───────────────────────────────────────────────────
+acl CONNECT method CONNECT
+http_access allow CONNECT allowed_domains
+http_access allow allowed_domains
+http_access deny all
+
+# ── Logging ─────────────────────────────────────────────────────────
+access_log stdio:/dev/stdout combined
+
+# ── Privacy and cache ───────────────────────────────────────────────
+cache deny all
+forwarded_for off
+via off

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -13,6 +13,10 @@ pid_filename none
 
 # ── Core tier — required for basic toolchain operation ────────────────
 acl allowed_domains dstdomain api.anthropic.com
+# Claude Code's own service endpoint — distinct from api.anthropic.com.
+# Confirmed required by a live 403 denial during a real session; the
+# original guide's allowlist only ever listed api.anthropic.com.
+acl allowed_domains dstdomain platform.claude.com
 acl allowed_domains dstdomain registry.npmjs.org
 acl allowed_domains dstdomain pypi.org
 acl allowed_domains dstdomain files.pythonhosted.org

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -6,6 +6,11 @@
 
 http_port 3128
 
+# Docker tracks this container's process directly; no PID file is needed,
+# and /run/squid.pid is not writable by the non-root "proxy" user (see SDD
+# §6.4, §9 — confirmed empirically during smoke testing, not assumed).
+pid_filename none
+
 # ── Core tier — required for basic toolchain operation ────────────────
 acl allowed_domains dstdomain api.anthropic.com
 acl allowed_domains dstdomain registry.npmjs.org
@@ -47,7 +52,10 @@ http_access allow allowed_domains
 http_access deny all
 
 # ── Logging ─────────────────────────────────────────────────────────
-access_log stdio:/dev/stdout combined
+# "squid" (native format, e.g. TCP_TUNNEL/200) — not "combined" (NCSA
+# format, e.g. TCP_TUNNEL:HIER_DIRECT). Confirmed empirically after a
+# bats S-1/S-3 failure traced to this exact format mismatch.
+access_log stdio:/dev/stdout squid
 
 # ── Privacy and cache ───────────────────────────────────────────────
 cache deny all

--- a/start.sh
+++ b/start.sh
@@ -59,12 +59,18 @@ if ! docker network inspect claude-net > /dev/null 2>&1; then
     exit 1
 fi
 
+if ! docker image inspect claude-squid > /dev/null 2>&1; then
+    echo "Error: image 'claude-squid' does not exist."
+    echo "Build it first with: ./build.sh squid"
+    exit 1
+fi
+
 GLOBAL_BASE="${SANDBOX_DIR}/global-claude"
 GLOBAL_OVERLAY="${SANDBOX_DIR}/global-${IMAGE_TAG}"
 
 echo "Project:  $PROJECT_DIR"
 echo "Image:    $IMAGE_NAME"
-echo "Network:  claude-net (Anthropic API + package registries only)"
+echo "Network:  claude-net via claude-squid proxy (see squid/squid.conf for allowlist)"
 
 if [ -d "$GLOBAL_BASE" ]; then
     echo "Global:   $GLOBAL_BASE"
@@ -101,6 +107,33 @@ if [ -d "$GLOBAL_OVERLAY" ] && [ "$IMAGE_TAG" != "base" ]; then
     )
 fi
 
+PROXY_NAME="claude-proxy-$$"
+
+# Guaranteed teardown regardless of how the script exits (normal completion,
+# main-container failure, or Ctrl+C) — a plain "stop after" line only runs
+# on the clean-exit path and would leak the proxy container otherwise.
+cleanup() {
+    local exit_code=$?
+    if docker ps -a --format '{{.Names}}' | grep -qx "$PROXY_NAME"; then
+        docker stop "$PROXY_NAME" > /dev/null 2>&1 || true
+        docker rm "$PROXY_NAME" > /dev/null 2>&1 || true
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+echo "Starting Squid proxy ($PROXY_NAME)..."
+if ! docker run -d \
+    --name "$PROXY_NAME" \
+    --network claude-net \
+    --cap-drop=ALL \
+    --security-opt=no-new-privileges \
+    claude-squid > /dev/null; then
+    echo "Error: Squid proxy failed to start."
+    echo "Fail-closed per docs/designs/squid-proxy-integration.md §6.3 — aborting session."
+    exit 1
+fi
+
 docker run \
     --rm \
     -it \
@@ -108,6 +141,9 @@ docker run \
     "${MOUNT_ARGS[@]}" \
     "${ENV_ARGS[@]}" \
     --network claude-net \
+    --env HTTP_PROXY="http://$PROXY_NAME:3128" \
+    --env HTTPS_PROXY="http://$PROXY_NAME:3128" \
+    --env NO_PROXY="localhost,127.0.0.1" \
     --memory="2g" \
     --cpus="2" \
     --security-opt=no-new-privileges \


### PR DESCRIPTION
## Summary

Closes the gap between `docs/squid_proxy_guide.md`'s claims and the tracked tree: `squid/` was never committed and `start.sh` had no proxy lifecycle at all, leaving Layer 4 (network egress allowlisting) a no-op. Full design and STRIDE analysis: `docs/designs/squid-proxy-integration.md` (Accepted).

- Adds `squid/Dockerfile` and `squid/squid.conf` — `dstdomain`-primary default-deny allowlist, non-root execution, digest-pinned base image.
- Adds a `squid` target to `build.sh`.
- Adds the full proxy lifecycle to `start.sh`: preflight check, `trap`-based teardown covering normal exit/failure/interrupt, **fail-closed** startup (session aborts rather than silently degrading to unrestricted egress), and `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` injection.
- Corrects `docs/squid_proxy_guide.md` Part 3 Step 4 and Part 5, which no longer matched the real implementation.
- Adds a changelog entry to `docs/claude_code_security_plan.md` (Change 15) documenting the STRIDE delta.

## Bugs found and fixed during smoke testing

All three were invisible from reading the config alone and only surfaced by actually running the proxy end-to-end:

- **Non-root startup crash**: `USER proxy` (a hardening addition beyond the original guide) left Squid unable to write `/run/squid.pid`. Fixed with `pid_filename none` — Docker already tracks the container's process directly.
- **Access log format mismatch**: `squid.conf` used the NCSA `combined` log format, but Part 4 of the guide and `test_squid_isolation.bats` both assume Squid's native `squid` format (`TCP_TUNNEL/200` vs. `TCP_TUNNEL:HIER_DIRECT`). This inconsistency predates this work — present in the guide's very first version. Fixed by switching the format.
- **Missing allowlist entry**: a live session hit a 403 on `platform.claude.com` — Claude Code's own service endpoint, distinct from `api.anthropic.com`, which the original guide's allowlist never included. Added.

## Test plan

- [x] `bats tests/test_squid_isolation.bats` — S-1/S-2/S-3 pass
- [x] `bats tests/` — full suite green
- [x] Manual `start.sh` session: Claude Code connects successfully; proxy correctly blocked an unlisted domain (Stack Overflow) and allowed a listed one (GitHub docs) mid-session
- [x] `trap` teardown verified via both clean exit and interrupt

Closes #12