### PR TITLE
feat: layered config file (config.sh / config.local.sh)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Per-machine config override — see config.local.sh.example and
+# docs/designs/sandbox-config-file.md. Never committed: it exists so an
+# operator can tune resource limits / engine choice for their own host
+# without touching the reviewed, shared config.sh.
+config.local.sh

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,8 +34,13 @@ inside /workspace — they don't need a dedicated image.
 
 ```
 ~/.claude-sandbox/
-├── build.sh          — builds all images (or a named target)
-├── start.sh          — launches a container for a given project
+├── build.sh                  — builds all images (or a named target)
+├── start.sh                  — launches a container for a given project
+├── config.sh                 — profile list, image prefix, engine default,
+│                                resource/log-driver values (committed)
+├── config.local.sh.example   — template for per-machine overrides (committed)
+├── config.local.sh           — your own overrides (gitignored, not present
+│                                until you create it)
 ├── base/
 │   └── Dockerfile
 ├── crypto/
@@ -46,6 +51,13 @@ inside /workspace — they don't need a dedicated image.
 │   └── Dockerfile
 └── tests/            — bats-core integration test harness (see BUILDING.md)
 ```
+
+`build.sh` and `start.sh` both source `config.sh` (then `config.local.sh`,
+if present) rather than hardcoding the profile list or runtime values
+themselves. Precedence, later wins: hardcoded fallback in the scripts <
+`config.sh` < `config.local.sh` < a matching env var at call time (e.g.
+`ENGINE=docker ./start.sh ...`). Full design rationale:
+[`docs/designs/sandbox-config-file.md`](docs/designs/sandbox-config-file.md).
 
 ### Build all images (do this once, and after any Dockerfile change)
 
@@ -131,6 +143,14 @@ pip is managed alongside the system Python.
 If it's an npm global tool, add it to the `npm install -g` invocation in
 `base/Dockerfile` LAYER 3, or add a new `RUN npm install -g <pkg>` line.
 
+**Adding an entirely new profile** (not just a tool inside an existing
+one) is a different, smaller step since the Podman migration: create the
+`<profile>/Dockerfile`, then register the profile in `config.sh` (add it
+to `PROFILES`, and to `PROFILE_BASE` if it builds on top of `base`).
+`build.sh` and `start.sh` both pick it up automatically — no other file
+needs editing. See [`config.sh`](config.sh) and
+[`docs/designs/sandbox-config-file.md`](docs/designs/sandbox-config-file.md).
+
 ---
 
 ## Strategy B — Ephemeral Install (Experiment First)
@@ -179,6 +199,13 @@ Start a session (pick the right image for your project type):
 Add a tool permanently:
   Edit the appropriate Dockerfile, add to the relevant layer
   ./build.sh [base|crypto|systems|research]
+
+Add a new profile:
+  Create <profile>/Dockerfile, register it in config.sh
+  (PROFILES + PROFILE_BASE) — build.sh/start.sh pick it up automatically
+
+Tune resource limits or engine for this machine only:
+  cp config.local.sh.example config.local.sh, edit — never committed
 
 Try a tool without committing:
   docker exec -u root -it <container-name> bash

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,27 @@
 # Building and Running
 
+## Configuration
+
+Profile list, image tag prefix, default engine, and `start.sh`'s resource
+limits / log-driver settings come from `config.sh` (committed) and,
+optionally, `config.local.sh` (gitignored — per-machine overrides, never
+committed). Precedence, later wins:
+
+```
+hardcoded defaults in build.sh/start.sh  <  config.sh  <  config.local.sh  <  env var
+```
+
+To override something on your own machine only (e.g. more memory, or a
+different default engine) without touching the shared, reviewed
+`config.sh`:
+
+```bash
+cp config.local.sh.example config.local.sh
+$EDITOR config.local.sh   # uncomment and edit only what you need
+```
+
+Full design rationale: [`docs/designs/sandbox-config-file.md`](docs/designs/sandbox-config-file.md).
+
 ## Prerequisites
 
 - Rootless Podman under WSL2 (default) — see

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,11 @@
 #
 # Place this file in the same directory as base/, crypto/, systems/, research/.
 #
+# Profile list, image prefix, and engine default come from config.sh (and
+# optionally config.local.sh, gitignored, per-machine). Precedence:
+# hardcoded defaults below < config.sh < config.local.sh < env var.
+# See docs/designs/sandbox-config-file.md.
+#
 # Engine:
 #   ENGINE=podman (default) or ENGINE=docker selects which container engine
 #   binary is invoked. See docs/designs/podman-migration.md. HOST_UID is only
@@ -26,7 +31,42 @@
 
 set -euo pipefail
 
-ENGINE="${ENGINE:-podman}"
+SANDBOX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Layer 4 capture: preserve any pre-set env var overrides before the
+# layers below can clobber them.
+_ENV_ENGINE="${ENGINE:-}"
+_ENV_IMAGE_PREFIX="${IMAGE_PREFIX:-}"
+
+# --- Layer 1: hardcoded defaults, so this script still works if config.sh
+# is missing.
+ENGINE="podman"
+IMAGE_PREFIX="claude"
+PROFILES=(base crypto systems research)
+declare -A PROFILE_BASE=(
+    [crypto]=base
+    [systems]=base
+    [research]=base
+)
+
+# --- Layer 2: committed, project-wide config.
+[ -f "${SANDBOX_DIR}/config.sh" ] && source "${SANDBOX_DIR}/config.sh"
+
+# --- Layer 3: gitignored, per-machine overrides.
+[ -f "${SANDBOX_DIR}/config.local.sh" ] && source "${SANDBOX_DIR}/config.local.sh"
+
+# --- Layer 4: env var wins over everything sourced above.
+ENGINE="${_ENV_ENGINE:-$ENGINE}"
+IMAGE_PREFIX="${_ENV_IMAGE_PREFIX:-$IMAGE_PREFIX}"
+
+is_profile() {
+    local candidate="$1"
+    local p
+    for p in "${PROFILES[@]}"; do
+        [ "$p" = "$candidate" ] && return 0
+    done
+    return 1
+}
 
 UID_ARG=""
 if [ "$ENGINE" = "docker" ]; then
@@ -42,66 +82,55 @@ for arg in "$@"; do
   esac
 done
 
-build_base() {
-    echo "→ Building claude-base..."
-    "$ENGINE" build $UID_ARG $NO_CACHE -t claude-base ./base/
+build_profile() {
+    local profile="$1"
+    local tag="${IMAGE_PREFIX}-${profile}"
+    echo "→ Building ${tag}..."
+    "$ENGINE" build $UID_ARG $NO_CACHE -t "${tag}" "${SANDBOX_DIR}/${profile}/"
 }
 
-build_crypto() {
-    echo "→ Building claude-crypto..."
-    "$ENGINE" build $UID_ARG $NO_CACHE -t claude-crypto ./crypto/
-}
-
-build_systems() {
-    echo "→ Building claude-systems..."
-    "$ENGINE" build $UID_ARG $NO_CACHE -t claude-systems ./systems/
-}
-
-build_research() {
-    echo "→ Building claude-research..."
-    "$ENGINE" build $UID_ARG $NO_CACHE -t claude-research ./research/
+# Builds a profile's base dependency first (if it has one), then the
+# profile itself.
+build_with_deps() {
+    local profile="$1"
+    local base="${PROFILE_BASE[$profile]:-}"
+    [ -n "$base" ] && build_profile "$base"
+    build_profile "$profile"
 }
 
 # No $UID_ARG — the Squid image creates no claude-agent-equivalent user tied
 # to the host UID; it has no bind-mounted /workspace and nothing that needs
 # host-UID alignment.
 build_squid() {
-    echo "→ Building claude-squid..."
-    "$ENGINE" build $NO_CACHE -t claude-squid ./squid/
+    local tag="${IMAGE_PREFIX}-squid"
+    echo "→ Building ${tag}..."
+    "$ENGINE" build $NO_CACHE -t "${tag}" "${SANDBOX_DIR}/squid/"
 }
 
 case "$TARGET" in
     all)
-        build_base
-        build_crypto
-        build_systems
-        build_research
+        build_profile "base"
+        for p in "${PROFILES[@]}"; do
+            [ "$p" = "base" ] && continue
+            build_profile "$p"
+        done
         build_squid
         echo ""
         echo "All images built:"
-        "$ENGINE" images | grep -E "^claude-(base|crypto|systems|research|squid)\s"
-        ;;
-    base)
-        build_base
-        ;;
-    crypto)
-        build_base
-        build_crypto
-        ;;
-    systems)
-        build_base
-        build_systems
-        ;;
-    research)
-        build_base
-        build_research
+        joined_profiles="$(IFS='|'; echo "${PROFILES[*]}")"
+        "$ENGINE" images | grep -E "^${IMAGE_PREFIX}-(${joined_profiles}|squid)\s"
         ;;
     squid)
         build_squid
         ;;
     *)
-        echo "Unknown target: $TARGET"
-        echo "Usage: $0 [all|base|crypto|systems|research|squid]"
-        exit 1
+        if is_profile "$TARGET"; then
+            build_with_deps "$TARGET"
+        else
+            joined_profiles="$(IFS='|'; echo "${PROFILES[*]}")"
+            echo "Unknown target: $TARGET"
+            echo "Usage: $0 [all|${joined_profiles}|squid]"
+            exit 1
+        fi
         ;;
 esac

--- a/config.local.sh.example
+++ b/config.local.sh.example
@@ -1,0 +1,27 @@
+# config.local.sh.example — copy to config.local.sh and edit.
+#
+# config.local.sh is gitignored — it is never committed to this project.
+# It holds one operator's per-machine overrides (resource limits,
+# preferred engine, a personal image prefix, etc.) without touching
+# config.sh, which is reviewed and shared by everyone.
+#
+# Precedence (later wins):
+#   hardcoded defaults < config.sh < config.local.sh (this file) < env var
+#
+# Uncomment only the values you want to override on this machine. Anything
+# left commented out falls through to config.sh's value.
+
+# ENGINE="docker"          # prefer Docker over Podman on this host
+# IMAGE_PREFIX="claude"    # e.g. if you've forked the images under a new prefix
+
+# MAIN_MEMORY="4g"         # this machine has more RAM to spare
+# MAIN_CPUS="4"
+# MAIN_LOG_MAX_SIZE="50m"
+# MAIN_LOG_MAX_FILE="5"
+
+# PROXY_LOG_MAX_SIZE="10m"
+# PROXY_LOG_MAX_FILE="3"
+
+# Profiles (PROFILES / PROFILE_BASE) are intentionally not meant to be
+# overridden per-machine — add or change a profile in config.sh instead,
+# since it affects what build.sh/start.sh accept for everyone.

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# config.sh — profile and runtime defaults for claude-sandbox.
+#
+# Committed, project-wide, reviewed. Sourced directly by build.sh and
+# start.sh — plain Bash variables and arrays, not a data format, so no
+# parser dependency is introduced (mirrors tests/lib/engine.bash, this
+# project's existing sourced-library pattern).
+#
+# Precedence (later wins):
+#   hardcoded defaults in build.sh/start.sh
+#     < config.sh (this file)
+#     < config.local.sh (gitignored, per-machine — see config.local.sh.example)
+#     < matching env var at call time (e.g. ENGINE=docker ./start.sh ...)
+#
+# Security-relevant values (resource limits, log options) are
+# version-controlled here; treat changes to this file with the same care
+# as a Dockerfile change. See docs/designs/sandbox-config-file.md.
+
+# Profiles start.sh accepts and build.sh knows how to build. "base" has no
+# entry in PROFILE_BASE below — it builds directly, not on top of anything.
+PROFILES=(base crypto systems research)
+
+# Maps a profile to its base-image dependency. A profile absent from this
+# map builds directly (currently only "base" itself).
+declare -A PROFILE_BASE=(
+    [crypto]=base
+    [systems]=base
+    [research]=base
+)
+
+IMAGE_PREFIX="claude"   # image tag = "${IMAGE_PREFIX}-${profile}"
+ENGINE="podman"         # container engine binary; ENGINE env var overrides at call time
+
+# Main session container (start.sh).
+MAIN_MEMORY="2g"
+MAIN_CPUS="2"
+MAIN_LOG_MAX_SIZE="50m"
+MAIN_LOG_MAX_FILE="5"
+
+# Squid proxy container (start.sh).
+PROXY_LOG_MAX_SIZE="10m"
+PROXY_LOG_MAX_FILE="3"

--- a/docs/designs/sandbox-config-file.md
+++ b/docs/designs/sandbox-config-file.md
@@ -1,0 +1,418 @@
+# Sandbox Config File
+
+## Status
+Accepted (revision 2 — adds a layered override mechanism on top of the
+previously drafted `config.sh`; the "what carries over from dev-env",
+format, and Case classification decisions below are unchanged from
+revision 1)
+
+## Context
+
+`claude-sandbox` has just completed its Docker → Podman migration
+(`docs/designs/podman-migration.md`), which was explicitly step two of
+three pre-merge tasks named in the testing SDD's own introduction:
+*"testing → Podman migration → config evaluation"*
+(`docs/designs/claude-sandbox-testing-module-sdd.md` line 51). This
+document is that third task.
+
+Today, profile and runtime configuration is hardcoded and duplicated
+across two files:
+
+- `build.sh` hardcodes the profile list via a `case` statement
+  (`base|crypto|systems|research|squid`), the base-before-children build
+  order, and a separate `ENGINE="${ENGINE:-podman}"` default.
+- `start.sh` independently hardcodes `VALID_IMAGES="base crypto systems
+  research"`, its own `ENGINE="${ENGINE:-podman}"` default, and the
+  session's resource limits and log-driver options
+  (`--memory="2g"`, `--cpus="2"`, `--log-opt max-size=...`) as literals.
+
+The profile list already has to be kept in sync by hand across both
+files — a real, pre-existing duplication problem independent of any
+comparison to `dev-env`. That duplication is the concrete motivation for
+this change; `dev-env` is the reference point because it's a sibling
+project (see repo tour, previous turn in this conversation) solving an
+adjacent problem — profile-aware containerized dev sessions — with a
+`config.toml` + `helpers.py` layer that centralizes exactly this kind of
+data.
+
+The two projects' threat models and constraints diverge in ways that
+matter for this design:
+
+- `dev-env` targets a **managed corporate Windows/WSL2 laptop** with a
+  security team that gates registry approval and reviews `config.toml`
+  changes against an ADR/SDD. `claude-sandbox` targets a single-user
+  local workstation (`docs/claude_code_security_plan.md`, Scope) — there
+  is no external reviewing body and no registry-approval control in its
+  existing threat model.
+- `dev-env`'s `run.sh` constructs its `podman run` command in a way that
+  makes a `forbidden_flags` runtime guard meaningful. `start.sh` has no
+  equivalent input path — its sandboxing flags (`--cap-drop=ALL`,
+  `--security-opt=no-new-privileges`, `--userns=keep-id`) are written
+  directly into the one `run` invocation, not assembled from
+  project-supplied input. There is nothing for a forbidden-flags check to
+  guard against here.
+- `dev-env` is a Python-using project (`helpers.py`, `tomllib`) with a
+  named-project registry (`[projects.<name>]`, resolved via
+  `$PROJECT_BASE`) and a `Makefile` as its sole public interface.
+  `claude-sandbox` is pure Bash today (`build.sh`, `start.sh`, plus
+  `tests/lib/engine.bash` for the bats-core harness), has no project
+  registry — `start.sh <project_dir> [profile]` takes an ad-hoc directory
+  positionally — and no `Makefile`. Per an explicit decision with the
+  operator during design, this positional interface stays: v1 is scoped
+  to profile/build/runtime config, not a project registry.
+
+**Revision 2 addition.** After agreeing the above, the operator asked for
+a second, orthogonal pattern on top of the single `config.sh`: a layered
+override chain —
+
+```
+default_values  <-  config.sh  <-  config.local.sh  <-  env var
+```
+
+— where `config.sh` stays committed (as designed below), and
+`config.local.sh` is a new, gitignored, per-machine file: "committed in a
+particular user instance" but never in the project itself. This is
+motivated by real per-machine variance this project's own docs already
+document (WSL2 vs. Fedora, SELinux enforcement, subuid ranges, cgroups v2
+delegation quirks — `BUILDING.md`'s Podman-prerequisites section) — an
+operator may reasonably want a different default `ENGINE`, or different
+`MAIN_MEMORY`/`MAIN_CPUS`, on their own machine without editing a file
+that's under code review.
+
+## Decision
+
+### What carries over vs. what doesn't
+
+| dev-env element | Carries over? | Rationale |
+|---|---|---|
+| Per-profile block shape (`containerfile_dir`, `image_name`, `image_version`, optional `base` dependency edge) | **Yes** | Directly maps onto `build.sh`'s existing base/crypto/systems/research hierarchy; removes the two-file duplication that motivated this change. |
+| A single source of truth read by both build and run scripts | **Yes** | Same problem dev-env solved (`setup.sh`/`run.sh` never hand-hardcode profile data); this is the core reusable idea, independent of file format. |
+| `[defaults]` username / workspace_mount | **No** | `claude-sandbox`'s user (`claude-agent`) and mount point (`/workspace`) are baked into the Dockerfiles and referenced directly by `start.sh`/`ARCHITECTURE.md`; there's no second consumer that needs them centralized, and `--userns=keep-id:uid=1000,gid=1000` already hardcodes the UID convention per `podman-migration.md` §3.A. |
+| `[registry] allowed[] / default` | **No** | This is a corporate approved-registry control gated by a security team review process `claude-sandbox` doesn't have. `claude-sandbox`'s equivalent control is digest-pinning the base image (`podman-migration.md` §5.3), a different and already-implemented mechanism. |
+| `runtime.forbidden_flags[]` + `check-forbidden-flags` guard | **No** | No analogue: `start.sh` never assembles its container-run command from project- or user-supplied flags, so there's nothing to check against a denylist. |
+| `[projects.<name>]` registry + `$PROJECT_BASE` | **No (v1)** | Confirmed out of scope with the operator — `start.sh`'s positional `<project_dir>` interface stays as-is. |
+| `helpers.py` as a Python CLI layer | **No** | See format decision below — introducing Python as a new host dependency isn't justified here. |
+| `Makefile` as sole public interface | **No** | `claude-sandbox` has no `Makefile` today and `ARCHITECTURE.md`'s documented Cheat Sheet already treats `build.sh`/`start.sh` as the direct entry points; adding an interface layer is out of scope for a config-centralization change. |
+| TOML as the format | **No** | See below. |
+| Resource limits / log-driver options as named, version-controlled fields | **Yes (spirit)** | Not present in dev-env's config at all, but the same principle — these are exactly the kind of value dev-env's config.toml header calls "security-relevant and version-controlled" — applies to `start.sh`'s `--memory`/`--cpus`/log-opt literals, which are currently undocumented magic strings. |
+
+### Format: a sourced Bash config, not TOML+Python
+
+`dev-env` uses TOML parsed by `helpers.py` (Python's `tomllib`) because it
+was already reasonable to assume a Python toolchain there. `claude-sandbox`
+has no Python anywhere — not in `build.sh`, not in `start.sh`, not in the
+bats-core test harness. Its established pattern for cross-script shared
+logic is `tests/lib/engine.bash`: a plain Bash library, sourced directly,
+no parser needed.
+
+**Decision: `config.sh` at the repo root, a plain Bash file defining
+arrays and variables, sourced directly by `build.sh` and `start.sh`.**
+
+```bash
+# config.sh — profile and runtime defaults for claude-sandbox.
+# Sourced directly by build.sh and start.sh. Bash arrays, not a data
+# format, so no parser dependency is introduced — consistent with
+# tests/lib/engine.bash, this project's existing sourced-library pattern.
+#
+# Security-relevant values (resource limits, log options) are
+# version-controlled here; treat changes to this file with the same care
+# as a Dockerfile change.
+
+PROFILES=(base crypto systems research)
+
+# Maps a profile to its base-image dependency. A profile absent from this
+# map builds directly (currently only "base" itself).
+declare -A PROFILE_BASE=(
+    [crypto]=base
+    [systems]=base
+    [research]=base
+)
+
+IMAGE_PREFIX="claude"          # image tag = "${IMAGE_PREFIX}-${profile}"
+ENGINE_DEFAULT="podman"        # ENGINE env var still overrides at call time
+
+MAIN_MEMORY="2g"
+MAIN_CPUS="2"
+MAIN_LOG_MAX_SIZE="50m"
+MAIN_LOG_MAX_FILE="5"
+
+PROXY_LOG_MAX_SIZE="10m"
+PROXY_LOG_MAX_FILE="3"
+```
+
+This gives every consumer (`build.sh`, `start.sh`, and any future bats
+test) the same data with zero new host prerequisites — `BUILDING.md`'s
+Prerequisites list stays exactly as it is (Podman/Docker, `gh`,
+`bats-core`); no `python3` or `yq` binary needs to be added to it.
+
+### Layered overrides: `default_values ← config.sh ← config.local.sh ← env var`
+
+Same mechanism as above — no new format, no new dependency — extended to
+four layers instead of one. Each later layer wins over the one before it.
+
+**Layer 1 — `default_values`.** Hardcoded literals at the top of
+`build.sh`/`start.sh` themselves, identical in value to what `config.sh`
+will also set. This means the scripts still run correctly even if
+`config.sh` is deleted or missing — the project doesn't become
+non-functional from a missing file.
+
+**Layer 2 — `config.sh`.** Committed, project-wide, reviewed — exactly as
+designed above.
+
+**Layer 3 — `config.local.sh`.** New. Gitignored. One operator's
+per-machine overrides. Same variable names as `config.sh`, only the
+fields the operator actually wants to change:
+
+```bash
+# config.local.sh.example — copy to config.local.sh and edit.
+# config.local.sh is gitignored — it is never committed to this project.
+# Uncomment only the values you want to override on this machine.
+# Precedence: default_values < config.sh < config.local.sh < env var.
+
+# ENGINE_DEFAULT="docker"      # prefer Docker over Podman on this host
+# MAIN_MEMORY="4g"             # this machine has more RAM to spare
+# MAIN_CPUS="4"
+```
+
+`config.local.sh.example` (the template above, with every field commented
+out) is committed — it's the discoverable list of what's overridable,
+the same role `dev-env`'s commented-out `[projects.another-project]`
+block plays in its `config.toml`. `config.local.sh` itself is never
+committed.
+
+**Layer 4 — env var.** Highest precedence, resolved last, at the point of
+use in `build.sh`/`start.sh` — matching the existing `ENGINE` convention
+(`ENGINE=docker ./start.sh ...`) rather than adding CLI flag parsing
+(confirmed with the operator: `start.sh`'s interface has been purely
+positional since the project began, and this change doesn't reopen that).
+
+**Mechanism detail that matters for correctness.** A naive
+`VAR="${VAR:-default}"` placed *after* sourcing `config.sh`/`config.local.sh`
+does not work as a layer-4 override: once `config.sh` assigns `VAR`, it is
+no longer unset, so a later `${VAR:-...}` is a no-op regardless of
+whether the operator exported an env var. The env var has to be captured
+*before* the two files are sourced, then re-applied after:
+
+```bash
+# In build.sh / start.sh, before sourcing anything:
+_ENV_ENGINE="${ENGINE:-}"
+_ENV_MAIN_MEMORY="${MAIN_MEMORY:-}"
+# ... one capture per overridable scalar
+
+# Layer 1: hardcoded defaults
+ENGINE="podman"
+MAIN_MEMORY="2g"
+# ...
+
+# Layer 2
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "${SCRIPT_DIR}/config.sh" ] && source "${SCRIPT_DIR}/config.sh"
+
+# Layer 3
+[ -f "${SCRIPT_DIR}/config.local.sh" ] && source "${SCRIPT_DIR}/config.local.sh"
+
+# Layer 4: env var wins over everything sourced above
+ENGINE="${_ENV_ENGINE:-$ENGINE}"
+MAIN_MEMORY="${_ENV_MAIN_MEMORY:-$MAIN_MEMORY}"
+```
+
+**Scope of layer 4:** applies to scalar values only (`ENGINE`,
+`IMAGE_PREFIX`, `MAIN_MEMORY`, `MAIN_CPUS`, `MAIN_LOG_MAX_SIZE`,
+`MAIN_LOG_MAX_FILE`, `PROXY_LOG_MAX_SIZE`, `PROXY_LOG_MAX_FILE`). Bash's
+associative array (`PROFILE_BASE`) and indexed array (`PROFILES`) are not
+made env-var-overridable — exporting a shell array through the
+environment is not a well-supported cross-shell pattern, and there's no
+existing need to override the profile list itself from a single
+invocation. Profile changes go through `config.sh` or `config.local.sh`
+only.
+
+**`.gitignore`.** `claude-sandbox` has no `.gitignore` today (checked:
+none exists at the repo root). This change adds one, with
+`config.local.sh` as its first entry. `config.local.sh.example` is
+committed normally (not ignored).
+
+**On the risk of accidentally committing `config.local.sh`:** a
+`.gitignore` entry is the right amount of protection here, not more.
+`settings.json`'s `Write(../*)`-style denylist entries guard against
+Claude Code writing outside the project directory — a different threat
+(a runaway agent action) from an operator manually `git add`-ing a file
+that they, not Claude, created and control. This project's own threat
+model scope (`docs/claude_code_security_plan.md`) is a single-user local
+workstation with no external reviewer — a `.gitignore` entry (plus, if
+it's ever committed by accident, `git rm --cached` and the normal review
+process catching an unexpected diff) is proportionate. Building a
+pre-commit hook or a `settings.json` write-guard for this would be
+over-engineering for a file whose worst-case content is "a different
+memory limit."
+
+### v1 scope
+
+**Becomes config-driven:**
+- Profile list and base-image dependency edges (replaces `build.sh`'s
+  `case` statement and `start.sh`'s `VALID_IMAGES` string).
+- Image tag prefix (replaces the hardcoded `claude-` string appearing in
+  both files).
+- `ENGINE` default (replaces the duplicated `"${ENGINE:-podman}"` line in
+  both files — env var override behavior is unchanged).
+- Main-container and proxy-container resource limits and log-driver
+  options (replaces the literals in `start.sh`'s `run` invocations).
+- All of the above, layered four ways (`default_values ← config.sh ←
+  config.local.sh ← env var`) rather than a single committed file.
+
+**Stays exactly as it is, out of scope for v1:**
+- `squid/squid.conf`'s domain allowlist — explicitly deferred per
+  `squid-proxy-integration.md` §3/§9 and reaffirmed in
+  `podman-migration.md` §3.C; this document doesn't reopen it.
+- The `global-claude/` / `global-<profile>/` overlay mechanism
+  (`docs/designs/global-layer-injection.md`) — `config.sh`'s profile
+  block adds *build* metadata (Dockerfile dir, image name, base). It does
+  not touch, replace, or duplicate the overlay-injection logic, which
+  keeps discovering `global-<profile>/` by directory presence exactly as
+  today.
+- `claude-squid`'s build — stays a special case in `build.sh`, not a
+  `PROFILES` entry, matching its existing separate handling (no base
+  dependency, no `start.sh`-selectable profile, no UID-matching need).
+- A named project registry (confirmed out of scope with the operator,
+  see Context).
+- A `helpers.py`-equivalent CLI (`list-sessions`, `stop-session`,
+  `status`, etc.) — `claude-sandbox` has no `make stop`/`make status`
+  today and none was requested; a plain sourced `config.sh` needs no CLI
+  wrapper since `build.sh`/`start.sh` read the arrays directly.
+
+### Case classification (docs-as-code-workflow.md)
+
+This is **Case C** — a structural change spanning `build.sh` and
+`start.sh`, introducing a new shared component (`config.sh`) that future
+changes will build on.
+
+It does **not** trigger **Case E** under this project's own definition:
+Case E's trigger list is `base/Dockerfile`, `base/entrypoint.sh`,
+`squid/squid.conf`, or the `permissions` block in `settings.json`
+specifically — none of which this change touches. The resource-limit and
+log-driver *values* are security-relevant, but they are being relocated
+verbatim (`2g`/`2`/`50m`/`5`/`10m`/`3` — unchanged from today), not
+altered — this is a refactor of where the values live, not a change to
+container security posture. No STRIDE section is required. If a future
+change to `config.sh` actually *changes* one of these values (not just
+moves it), that change should be evaluated against Case E's criteria at
+that time, since it would then be altering runtime security posture.
+
+## Consequences
+
+**Easier:**
+- Adding a profile becomes one `config.sh` edit (array entry + optional
+  `PROFILE_BASE` entry) instead of two hand-synced edits across
+  `build.sh`'s `case` statement and `start.sh`'s `VALID_IMAGES` string —
+  removes an existing drift hazard.
+- Resource limits and log options become named, documented,
+  version-controlled values instead of literals buried in `start.sh`'s
+  `run` invocation — easier to review and to cite in future STRIDE
+  updates to `claude_code_security_plan.md`.
+- `ARCHITECTURE.md`'s Strategy A workflow ("add to the relevant
+  Dockerfile, rebuild") gets a small, natural extension: also add the
+  profile to `config.sh`.
+- An operator can tune resource limits or their preferred engine for
+  their own machine (`config.local.sh`) without touching a file under
+  code review, and without that preference leaking into anyone else's
+  checkout or the project's git history.
+
+**Harder / trade-offs:**
+- One more file to keep in sync with the Dockerfile directories
+  (`base/`, `crypto/`, `systems/`, `research/`) — mitigated by the bats
+  regression test in the implementation plan below, which asserts
+  `config.sh`'s `PROFILES` matches the directories actually present.
+- `config.sh` is executable Bash sourced into two scripts' process state
+  — a typo (e.g. a stray command instead of a variable assignment) fails
+  differently than a TOML syntax error would (a TOML parser fails
+  loudly and immediately; a sourced Bash file can silently execute
+  something unintended). Mitigated by keeping `config.sh` data-only (no
+  logic, no command substitution beyond simple literals) and by the same
+  bats regression test.
+- Four layers is more to reason about when debugging "why is my session
+  using 4g of memory" — mitigated by having `start.sh` print which value
+  it resolved (not just the flag) in its existing startup summary, and by
+  the precedence order being identical and documented in one place
+  (`config.sh`'s own header comment) rather than different per script.
+- `config.local.sh` is, by design, never code-reviewed — it's gitignored
+  specifically so it can diverge per machine. This is an accepted,
+  deliberate trade-off for a single-user local tool (see the `.gitignore`
+  discussion above), not an oversight, but it does mean this project's
+  otherwise-universal "everything is version-controlled and auditable"
+  property has one narrow, intentional exception.
+- The capture-before-source idiom for layer 4 (see above) adds a few
+  lines of boilerplate per overridable scalar in both `build.sh` and
+  `start.sh` — mechanical, but real line count, and a new contributor
+  needs to understand *why* it's not just a trailing `${VAR:-default}`.
+
+## Alternatives considered
+
+- **Port `helpers.py` + TOML as-is.** Rejected: introduces Python as a
+  new host prerequisite for a project that is currently pure Bash
+  end-to-end, for no benefit `config.sh` doesn't already provide at this
+  scope. Revisit only if a future need (e.g. genuinely complex nested
+  config, or a CLI wrapper with many subcommands like dev-env's) justifies
+  the added dependency.
+- **`yq` (YAML/TOML/JSON CLI parser).** Rejected: adds a new host binary
+  dependency for the same reason a Python parser would, without even the
+  benefit of a language already used elsewhere in the stack.
+- **JSON + `jq`.** Same objection as `yq`; also `jq` is not currently in
+  `BUILDING.md`'s prerequisites, so it's a wash on shell-nativeness.
+- **Add fields to `settings.json`.** Rejected: `settings.json` is
+  explicitly scoped in this project's own workflow doc as the file
+  governing the Claude Code permission denylist (Case E trigger); mixing
+  build/runtime profile config into it would blur that boundary and
+  incorrectly widen what counts as a Case E change.
+- **Only one committed `config.sh`, no local layer.** Rejected: gives no
+  way to tune per-machine values (resource limits, preferred engine)
+  without editing a file under code review — an operator would have to
+  either commit a personal preference project-wide or keep a local diff
+  they must remember to never commit. `config.local.sh` solves this
+  directly.
+- **A `.env`-style `KEY=value` file for the local layer instead of sourced
+  Bash.** Rejected: would require a second read mechanism (a `.env`
+  parser) alongside the sourced-Bash `config.sh`, for no real gain —
+  `config.local.sh` needs the exact same shape as `config.sh` (it's
+  overriding the same variables), so reusing the identical `source`
+  mechanism keeps this to one pattern, not two.
+- **CLI flags (`--memory=4g`) as the layer-4 override.** Rejected per the
+  operator's explicit choice — env vars keep `start.sh` purely positional,
+  matching its interface since the project began, and reuse the existing
+  `ENGINE=` mental model rather than introducing a new one.
+
+## Implementation plan
+
+1. Add `config.sh` at the repo root with the shape shown above,
+   populated with today's actual values (`PROFILES`, `PROFILE_BASE`,
+   `IMAGE_PREFIX=claude`, `ENGINE_DEFAULT=podman`, and the resource/log
+   values currently hardcoded in `start.sh`), plus a header comment
+   stating the full precedence chain (`default_values < config.sh <
+   config.local.sh < env var`). No behavior change yet — single-file
+   atomic commit.
+2. Add `.gitignore` (new file) with `config.local.sh` as its first entry.
+   Add `config.local.sh.example` (committed template, all fields
+   commented out, per the shape shown above). Single commit.
+3. Update `build.sh`: capture pre-set env-var overrides, set layer-1
+   hardcoded defaults, `source config.sh` then `source config.local.sh`
+   (both guarded by `[ -f ... ]`), re-apply the captured env-var layer,
+   replace the `case` statement's per-profile `build_*` dispatch with a
+   loop driven by `PROFILES` + `PROFILE_BASE`. `build_squid` stays a
+   distinct function, not part of the loop. Regression gate:
+   `bats tests/test_build.bats` (`ENGINE=docker` and `ENGINE=podman`)
+   must still pass unchanged.
+4. Update `start.sh` with the same four-layer resolution, replace
+   `VALID_IMAGES` with `PROFILES` (and its derived error message), and
+   replace the `--memory`/`--cpus`/log-opt literals with the resolved
+   values. Regression gate: `bats tests/test_runtime_posture.bats
+   tests/test_global_layer.bats` unchanged.
+5. Add a bats regression test (new `tests/test_config.bats` or an
+   addition to an existing file) asserting: (a) `config.sh`'s `PROFILES`
+   matches the profile directories actually present in the repo root,
+   (b) `build.sh`/`start.sh` derive identical profile lists from it, and
+   (c) an env var override (e.g. `ENGINE=docker`) still wins even when
+   `config.sh`/`config.local.sh` set a different value — the specific
+   correctness property the capture-before-source idiom exists for.
+6. Update `ARCHITECTURE.md`'s "Add a tool permanently" / Strategy A
+   section and `BUILDING.md` to mention `config.sh`, `config.local.sh`,
+   the precedence chain, and the (now one-file-for-shared,
+   one-file-for-personal) procedure for adding or tuning a profile.
+7. Single commit closing the tracking issue, per Case C convention.

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@
 # Arguments:
 #   project_directory  — path to the project to mount (default: current dir)
 #   image              — which sandbox image to use (default: base)
-#                        one of: base, crypto, systems, research
+#                        one of the profiles defined in config.sh
 #
 # Global layer directories (relative to this script's location):
 #   global-claude/        — base layer, injected into every session
@@ -20,20 +20,61 @@
 #   podman network create --driver bridge claude-net
 #   (or: docker network create --driver bridge claude-net, under ENGINE=docker)
 #
+# Profile list, image prefix, engine default, and resource/log-driver
+# settings come from config.sh (and optionally config.local.sh, gitignored,
+# per-machine). Precedence: hardcoded defaults below < config.sh <
+# config.local.sh < env var. See docs/designs/sandbox-config-file.md.
+#
 # Engine:
 #   ENGINE=podman (default) or ENGINE=docker selects which container engine
 #   binary is invoked. See docs/designs/podman-migration.md.
 
 set -euo pipefail
 
-ENGINE="${ENGINE:-podman}"
-
 SANDBOX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Layer 4 capture: preserve any pre-set env var overrides before the
+# layers below can clobber them.
+_ENV_ENGINE="${ENGINE:-}"
+_ENV_IMAGE_PREFIX="${IMAGE_PREFIX:-}"
+_ENV_MAIN_MEMORY="${MAIN_MEMORY:-}"
+_ENV_MAIN_CPUS="${MAIN_CPUS:-}"
+_ENV_MAIN_LOG_MAX_SIZE="${MAIN_LOG_MAX_SIZE:-}"
+_ENV_MAIN_LOG_MAX_FILE="${MAIN_LOG_MAX_FILE:-}"
+_ENV_PROXY_LOG_MAX_SIZE="${PROXY_LOG_MAX_SIZE:-}"
+_ENV_PROXY_LOG_MAX_FILE="${PROXY_LOG_MAX_FILE:-}"
+
+# --- Layer 1: hardcoded defaults, so this script still works if config.sh
+# is missing.
+ENGINE="podman"
+IMAGE_PREFIX="claude"
+PROFILES=(base crypto systems research)
+MAIN_MEMORY="2g"
+MAIN_CPUS="2"
+MAIN_LOG_MAX_SIZE="50m"
+MAIN_LOG_MAX_FILE="5"
+PROXY_LOG_MAX_SIZE="10m"
+PROXY_LOG_MAX_FILE="3"
+
+# --- Layer 2: committed, project-wide config.
+[ -f "${SANDBOX_DIR}/config.sh" ] && source "${SANDBOX_DIR}/config.sh"
+
+# --- Layer 3: gitignored, per-machine overrides.
+[ -f "${SANDBOX_DIR}/config.local.sh" ] && source "${SANDBOX_DIR}/config.local.sh"
+
+# --- Layer 4: env var wins over everything sourced above.
+ENGINE="${_ENV_ENGINE:-$ENGINE}"
+IMAGE_PREFIX="${_ENV_IMAGE_PREFIX:-$IMAGE_PREFIX}"
+MAIN_MEMORY="${_ENV_MAIN_MEMORY:-$MAIN_MEMORY}"
+MAIN_CPUS="${_ENV_MAIN_CPUS:-$MAIN_CPUS}"
+MAIN_LOG_MAX_SIZE="${_ENV_MAIN_LOG_MAX_SIZE:-$MAIN_LOG_MAX_SIZE}"
+MAIN_LOG_MAX_FILE="${_ENV_MAIN_LOG_MAX_FILE:-$MAIN_LOG_MAX_FILE}"
+PROXY_LOG_MAX_SIZE="${_ENV_PROXY_LOG_MAX_SIZE:-$PROXY_LOG_MAX_SIZE}"
+PROXY_LOG_MAX_FILE="${_ENV_PROXY_LOG_MAX_FILE:-$PROXY_LOG_MAX_FILE}"
+
 PROJECT_DIR="${1:-$(pwd)}"
 PROJECT_DIR="$(realpath "$PROJECT_DIR")"
 IMAGE_TAG="${2:-base}"
-
-VALID_IMAGES="base crypto systems research"
 
 if ! "$ENGINE" info > /dev/null 2>&1; then
     echo "Error: $ENGINE is not reachable."
@@ -46,13 +87,13 @@ if [ ! -d "$PROJECT_DIR" ]; then
     exit 1
 fi
 
-if ! echo "$VALID_IMAGES" | grep -qw "$IMAGE_TAG"; then
+if ! printf '%s\n' "${PROFILES[@]}" | grep -qx "$IMAGE_TAG"; then
     echo "Error: unknown image '$IMAGE_TAG'."
-    echo "Valid options: $VALID_IMAGES"
+    echo "Valid options: ${PROFILES[*]}"
     exit 1
 fi
 
-IMAGE_NAME="claude-${IMAGE_TAG}"
+IMAGE_NAME="${IMAGE_PREFIX}-${IMAGE_TAG}"
 
 if ! "$ENGINE" image inspect "$IMAGE_NAME" > /dev/null 2>&1; then
     echo "Error: image '$IMAGE_NAME' does not exist."
@@ -66,8 +107,9 @@ if ! "$ENGINE" network inspect claude-net > /dev/null 2>&1; then
     exit 1
 fi
 
-if ! "$ENGINE" image inspect claude-squid > /dev/null 2>&1; then
-    echo "Error: image 'claude-squid' does not exist."
+SQUID_IMAGE_NAME="${IMAGE_PREFIX}-squid"
+if ! "$ENGINE" image inspect "$SQUID_IMAGE_NAME" > /dev/null 2>&1; then
+    echo "Error: image '$SQUID_IMAGE_NAME' does not exist."
     echo "Build it first with: ./build.sh squid"
     exit 1
 fi
@@ -77,7 +119,7 @@ GLOBAL_OVERLAY="${SANDBOX_DIR}/global-${IMAGE_TAG}"
 
 echo "Project:  $PROJECT_DIR"
 echo "Image:    $IMAGE_NAME"
-echo "Network:  claude-net via claude-squid proxy (see squid/squid.conf for allowlist)"
+echo "Network:  claude-net via ${SQUID_IMAGE_NAME} proxy (see squid/squid.conf for allowlist)"
 
 if [ -d "$GLOBAL_BASE" ]; then
     echo "Global:   $GLOBAL_BASE"
@@ -167,8 +209,10 @@ fi
 # (Podman's default varies by configuration). Closes the proxy hygiene gap
 # noted in squid-proxy-integration.md §6.2-R and the main-container gap noted
 # in claude_code_security_plan.md Phase 5. See podman-migration.md §3.B.
-PROXY_LOG_ARGS=(--log-driver json-file --log-opt max-size=10m --log-opt max-file=3)
-MAIN_LOG_ARGS=(--log-driver json-file --log-opt max-size=50m --log-opt max-file=5)
+# Size/count values come from config.sh (see header) — same defaults as
+# before this became config-driven.
+PROXY_LOG_ARGS=(--log-driver json-file --log-opt "max-size=${PROXY_LOG_MAX_SIZE}" --log-opt "max-file=${PROXY_LOG_MAX_FILE}")
+MAIN_LOG_ARGS=(--log-driver json-file --log-opt "max-size=${MAIN_LOG_MAX_SIZE}" --log-opt "max-file=${MAIN_LOG_MAX_FILE}")
 
 echo "Starting Squid proxy ($PROXY_NAME)..."
 if ! "$ENGINE" run -d \
@@ -177,7 +221,7 @@ if ! "$ENGINE" run -d \
     --cap-drop=ALL \
     --security-opt=no-new-privileges \
     "${PROXY_LOG_ARGS[@]}" \
-    claude-squid > /dev/null; then
+    "$SQUID_IMAGE_NAME" > /dev/null; then
     echo "Error: Squid proxy failed to start."
     echo "Fail-closed per docs/designs/squid-proxy-integration.md §6.3 — aborting session."
     exit 1
@@ -193,8 +237,8 @@ fi
     --env HTTP_PROXY="http://$PROXY_NAME:3128" \
     --env HTTPS_PROXY="http://$PROXY_NAME:3128" \
     --env NO_PROXY="localhost,127.0.0.1" \
-    --memory="2g" \
-    --cpus="2" \
+    --memory="${MAIN_MEMORY}" \
+    --cpus="${MAIN_CPUS}" \
     --security-opt=no-new-privileges \
     --cap-drop=ALL \
     "${USERNS_ARGS[@]}" \

--- a/tests/test_config.bats
+++ b/tests/test_config.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# test_config.bats — Group: Layered Config (docs/designs/sandbox-config-file.md)
+#
+# Covers config.sh's own correctness and the four-layer precedence chain
+# (hardcoded defaults < config.sh < config.local.sh < env var), not
+# container runtime behavior — no engine daemon is required for any test
+# in this file, so setup() does not gate on engine_available.
+#
+# None of these tests touch a real config.local.sh: an operator's own
+# gitignored file must never be read, written, or deleted by the test
+# suite (see docs/designs/sandbox-config-file.md's discussion of why a
+# .gitignore entry, not test tooling, is the boundary here).
+
+SANDBOX_DIR="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+
+@test "C-1: env var overrides config.sh's value for the same variable" {
+    # bats test_tags=fast
+    run env ENGINE=docker bash -c '
+        set -euo pipefail
+        cd "'"${SANDBOX_DIR}"'"
+        _ENV_ENGINE="${ENGINE:-}"
+        ENGINE="podman"
+        source "./config.sh"
+        ENGINE="${_ENV_ENGINE:-$ENGINE}"
+        echo "$ENGINE"
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "docker" ]
+}
+
+@test "C-2: config.sh overrides the hardcoded layer-1 default when no env var is set" {
+    # bats test_tags=fast
+    run bash -c '
+        set -euo pipefail
+        cd "'"${SANDBOX_DIR}"'"
+        ENGINE="sentinel-default-value"
+        source "./config.sh"
+        echo "$ENGINE"
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" != "sentinel-default-value" ]
+}
+
+@test "C-3: config.sh's PROFILES matches the profile directories actually present" {
+    # bats test_tags=fast
+    run bash -c '
+        set -euo pipefail
+        cd "'"${SANDBOX_DIR}"'"
+        source "./config.sh"
+        printf "%s\n" "${PROFILES[@]}"
+    '
+    [ "$status" -eq 0 ]
+
+    for dir in base crypto systems research; do
+        [ -f "${SANDBOX_DIR}/${dir}/Dockerfile" ]
+        echo "$output" | grep -qx "$dir"
+    done
+}
+
+@test "C-4: config.sh's PROFILE_BASE only references profiles PROFILES actually declares" {
+    # bats test_tags=fast
+    # Regression guard: a typo'd or stale base-dependency entry (e.g.
+    # pointing at a renamed/removed profile) would silently no-op the
+    # build.sh dependency lookup rather than fail loudly.
+    run bash -c '
+        set -euo pipefail
+        cd "'"${SANDBOX_DIR}"'"
+        source "./config.sh"
+        for key in "${!PROFILE_BASE[@]}"; do
+            printf "%s\n" "${PROFILE_BASE[$key]}"
+        done
+    '
+    [ "$status" -eq 0 ]
+
+    profiles_list=$(bash -c '
+        set -euo pipefail
+        cd "'"${SANDBOX_DIR}"'"
+        source "./config.sh"
+        printf "%s\n" "${PROFILES[@]}"
+    ')
+
+    while IFS= read -r base_dep; do
+        [ -z "$base_dep" ] && continue
+        echo "$profiles_list" | grep -qx "$base_dep"
+    done <<< "$output"
+}
+
+@test "C-5: build.sh rejects a target not present in config.sh's PROFILES, without touching an engine" {
+    # bats test_tags=fast
+    # No engine daemon required: dispatch to the "Unknown target" branch
+    # happens before build.sh ever shells out to $ENGINE.
+    run bash "${SANDBOX_DIR}/build.sh" definitely-not-a-real-profile
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown target"* ]]
+}
+
+@test "C-6: build.sh and start.sh both source config.sh, not a re-copied literal list" {
+    # bats test_tags=fast
+    # Structural guard for the drift problem this design exists to fix:
+    # both scripts must read PROFILES from the same sourced file rather
+    # than hardcoding their own copies that could silently diverge again.
+    grep -Eq 'source "\$\{?SANDBOX_DIR\}?/config\.sh"' "${SANDBOX_DIR}/build.sh"
+    grep -Eq 'source "\$\{?SANDBOX_DIR\}?/config\.sh"' "${SANDBOX_DIR}/start.sh"
+}


### PR DESCRIPTION
## Summary
- Centralizes claude-sandbox's profile/build/runtime config, previously hardcoded and duplicated across `build.sh` and `start.sh`, into a single sourced `config.sh`
- Adds a gitignored `config.local.sh` layer (template: `config.local.sh.example`) for per-machine overrides — resource limits, preferred engine, etc. — without touching the reviewed, shared `config.sh`
- Precedence, later wins: `hardcoded defaults < config.sh < config.local.sh < env var` (e.g. `ENGINE=docker ./start.sh ...` still wins over everything)

Design doc: `docs/designs/sandbox-config-file.md` (evaluates what carries over from the sibling `dev-env` project's `config.toml`/`helpers.py` pattern vs. what's tailored to claude-sandbox's own threat model and pure-Bash toolchain).

## Test plan
- [ ] `bats tests/test_config.bats` — new layering regression tests (env var overrides config.sh, config.sh overrides hardcoded default, `PROFILES` matches real Dockerfile directories, `PROFILE_BASE` references are all valid, `build.sh` rejects an unknown profile without touching an engine, both scripts source `config.sh` rather than re-hardcoding)
- [ ] `bats tests/test_build.bats` — confirm B-1/B-2/B-3/B-4 still pass unchanged (build ordering, HOST_UID propagation, standalone Dockerfile builds, no `:latest` pins)
- [ ] `bats tests/test_runtime_posture.bats tests/test_global_layer.bats` — confirm R-1..R-8 and G-1..G-6 still pass unchanged (unknown/missing image rejection messages, resource-limit enforcement, SELinux relabeling, global layer injection)
- [ ] Manual: `./start.sh <project> crypto` still starts a session with the same resource limits/log options as before
- [ ] Manual: `cp config.local.sh.example config.local.sh`, override `MAIN_MEMORY`, confirm it takes effect and is not picked up by `git status`

Closes #28