### PR TITLE
feat(squid): allow official Claude Code and Anthropic docs

### DIFF
--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -2,6 +2,14 @@
 # Default-deny outbound policy. dstdomain (exact match) is the primary
 # mechanism; dstdom_regex is used only for the individually-justified
 # exception below, anchored, with its own comment.
+#
+# The regex exception lives under its own ACL name (allowed_cdn_domains),
+# not folded into allowed_domains: Squid treats reusing an ACL name with
+# a different acl type as a fatal config error ("already exists with
+# different type") and refuses to start — discovered the hard way when
+# the first real dstdom_regex entry was added under "allowed_domains"
+# and every access-log-based test failed, not just the new ones (issue
+# #32). http_access ORs the two names via separate allow lines instead.
 # ─────────────────────────────────────────────────────────────────────
 
 http_port 3128
@@ -52,18 +60,21 @@ acl allowed_domains dstdomain tug.org
 # ── dstdom_regex exceptions ─────────────────────────────────────────
 # Reserved for individually-justified, anchored patterns only — e.g. a
 # registry's rotating CDN-edge subdomain that a flat list can't track.
+# Own ACL name (not allowed_domains) — see header comment on why.
 #
 # mintcdn.com — CDN host for docs.anthropic.com and code.claude.com's
 # static assets (JS/CSS/fonts/search index). Both sites are Mintlify-
 # hosted; a flat dstdomain entry for the page domains alone does not
 # cover this. Anchored to mintcdn.com and any of its subdomains only.
 # See issue #32.
-acl allowed_domains dstdom_regex ^([a-z0-9-]+\.)*mintcdn\.com$
+acl allowed_cdn_domains dstdom_regex ^([a-z0-9-]+\.)*mintcdn\.com$
 
 # ── Access policy ───────────────────────────────────────────────────
 acl CONNECT method CONNECT
 http_access allow CONNECT allowed_domains
+http_access allow CONNECT allowed_cdn_domains
 http_access allow allowed_domains
+http_access allow allowed_cdn_domains
 http_access deny all
 
 # ── Logging ─────────────────────────────────────────────────────────

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -31,6 +31,12 @@ acl allowed_domains dstdomain raw.githubusercontent.com
 acl allowed_domains dstdomain docs.python.org
 acl allowed_domains dstdomain nodejs.org
 acl allowed_domains dstdomain developer.mozilla.org
+# Official Claude Code / Anthropic docs — see issue #32. Both are
+# Mintlify-hosted; their static assets (JS/CSS/fonts/search index) are
+# served from mintcdn.com, not from these domains themselves, so the
+# dstdom_regex exception below is required alongside these two entries.
+acl allowed_domains dstdomain docs.anthropic.com
+acl allowed_domains dstdomain code.claude.com
 
 # systems profile
 acl allowed_domains dstdomain en.cppreference.com
@@ -43,11 +49,16 @@ acl allowed_domains dstdomain www.openssl.org
 acl allowed_domains dstdomain ctan.org
 acl allowed_domains dstdomain tug.org
 
-# ── dstdom_regex exceptions (none at initial implementation) ──────────
+# ── dstdom_regex exceptions ─────────────────────────────────────────
 # Reserved for individually-justified, anchored patterns only — e.g. a
 # registry's rotating CDN-edge subdomain that a flat list can't track.
-# Example (commented, not active):
-# acl allowed_domains dstdom_regex ^[a-z0-9-]+\.pkg-cdn\.example\.com$
+#
+# mintcdn.com — CDN host for docs.anthropic.com and code.claude.com's
+# static assets (JS/CSS/fonts/search index). Both sites are Mintlify-
+# hosted; a flat dstdomain entry for the page domains alone does not
+# cover this. Anchored to mintcdn.com and any of its subdomains only.
+# See issue #32.
+acl allowed_domains dstdom_regex ^([a-z0-9-]+\.)*mintcdn\.com$
 
 # ── Access policy ───────────────────────────────────────────────────
 acl CONNECT method CONNECT

--- a/tests/test_squid_isolation.bats
+++ b/tests/test_squid_isolation.bats
@@ -22,6 +22,13 @@
 # the operator — so this suite cannot build or commit it (out of scope per
 # SDD §2.3); if it's missing, setup fails loudly rather than silently
 # skipping (SDD §8).
+#
+# The curl helper image is pinned to docker.io/curlimages/curl:latest,
+# fully qualified — an unqualified curlimages/curl:latest depends on
+# the operator's podman unqualified-search-registries order and can
+# silently resolve to a registry that doesn't carry the image (e.g.
+# registry.fedoraproject.org), failing every request in setup_file()
+# before any of them reach the proxy at all.
 
 load 'lib/engine'
 
@@ -51,26 +58,26 @@ setup_file() {
     # S-1 below is what asserts on it.
     engine_run --rm --network claude-net \
         --env HTTPS_PROXY="http://${proxy_name}:3128" \
-        curlimages/curl:latest curl -s -o /dev/null https://api.anthropic.com >&2 || true
+        docker.io/curlimages/curl:latest curl -s -o /dev/null https://api.anthropic.com >&2 || true
 
     # Blocked domain — expect refusal.
     engine_run --rm --network claude-net \
         --env HTTPS_PROXY="http://${proxy_name}:3128" \
-        curlimages/curl:latest curl -s -o /dev/null https://example.com >&2 || true
+        docker.io/curlimages/curl:latest curl -s -o /dev/null https://example.com >&2 || true
 
     # Allowed domains — issue #32 Reference-tier additions. S-4/S-5 assert on these.
     engine_run --rm --network claude-net \
         --env HTTPS_PROXY="http://${proxy_name}:3128" \
-        curlimages/curl:latest curl -s -o /dev/null https://docs.anthropic.com >&2 || true
+        docker.io/curlimages/curl:latest curl -s -o /dev/null https://docs.anthropic.com >&2 || true
 
     engine_run --rm --network claude-net \
         --env HTTPS_PROXY="http://${proxy_name}:3128" \
-        curlimages/curl:latest curl -s -o /dev/null https://code.claude.com >&2 || true
+        docker.io/curlimages/curl:latest curl -s -o /dev/null https://code.claude.com >&2 || true
 
     # dstdom_regex exception — issue #32. S-6 asserts on this.
     engine_run --rm --network claude-net \
         --env HTTPS_PROXY="http://${proxy_name}:3128" \
-        curlimages/curl:latest curl -s -o /dev/null https://mintcdn.com >&2 || true
+        docker.io/curlimages/curl:latest curl -s -o /dev/null https://mintcdn.com >&2 || true
 }
 
 teardown_file() {

--- a/tests/test_squid_isolation.bats
+++ b/tests/test_squid_isolation.bats
@@ -3,10 +3,18 @@
 #
 # Slow tier. Builds a test-tagged Squid image and runs it as a sibling
 # container on the shared claude-net network (never deleting that network,
-# per SDD §5). Both the allowed and the blocked request are made once in
-# setup_file() so all three assertions read the same accumulated access log.
-# State crosses the setup_file/test/teardown_file process boundary via
-# BATS_FILE_TMPDIR, since each of those runs in its own subshell.
+# per SDD §5). All allowed requests and the one blocked request are made
+# once in setup_file() so every assertion reads the same accumulated
+# access log. State crosses the setup_file/test/teardown_file process
+# boundary via BATS_FILE_TMPDIR, since each of those runs in its own
+# subshell.
+#
+# S-4/S-5 cover the docs.anthropic.com / code.claude.com Reference-tier
+# additions from issue #32. S-6 covers the dstdom_regex mintcdn.com CDN
+# exception added alongside them, curling the bare mintcdn.com apex —
+# Mintlify's own CSP configuration docs list plain "mintcdn.com" (not
+# just "*.mintcdn.com") as required for img-src/connect-src, confirming
+# it's a directly-addressable host and not merely a wildcard zone.
 #
 # Requires a squid/ directory (Dockerfile + squid.conf) as a sibling of
 # base/crypto/systems/research, per docs/squid_proxy_guide.md Part 3 Steps
@@ -49,6 +57,20 @@ setup_file() {
     engine_run --rm --network claude-net \
         --env HTTPS_PROXY="http://${proxy_name}:3128" \
         curlimages/curl:latest curl -s -o /dev/null https://example.com >&2 || true
+
+    # Allowed domains — issue #32 Reference-tier additions. S-4/S-5 assert on these.
+    engine_run --rm --network claude-net \
+        --env HTTPS_PROXY="http://${proxy_name}:3128" \
+        curlimages/curl:latest curl -s -o /dev/null https://docs.anthropic.com >&2 || true
+
+    engine_run --rm --network claude-net \
+        --env HTTPS_PROXY="http://${proxy_name}:3128" \
+        curlimages/curl:latest curl -s -o /dev/null https://code.claude.com >&2 || true
+
+    # dstdom_regex exception — issue #32. S-6 asserts on this.
+    engine_run --rm --network claude-net \
+        --env HTTPS_PROXY="http://${proxy_name}:3128" \
+        curlimages/curl:latest curl -s -o /dev/null https://mintcdn.com >&2 || true
 }
 
 teardown_file() {
@@ -83,5 +105,23 @@ proxy_logs() {
     run proxy_logs
     [ "$status" -eq 0 ]
     line_count=$(echo "$output" | grep -cE '^[0-9]+\.[0-9]+[[:space:]]+[0-9]+[[:space:]]+[0-9.]+[[:space:]]+\S+/[0-9]+')
-    [ "$line_count" -ge 2 ]
+    [ "$line_count" -ge 5 ]
+}
+
+@test "S-4: request to docs.anthropic.com (issue #32 Reference tier addition) succeeds" {
+    # bats test_tags=slow
+    run proxy_logs
+    [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+docs\.anthropic\.com:443 ]]
+}
+
+@test "S-5: request to code.claude.com (issue #32 Reference tier addition) succeeds" {
+    # bats test_tags=slow
+    run proxy_logs
+    [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+code\.claude\.com:443 ]]
+}
+
+@test "S-6: request to mintcdn.com (issue #32 dstdom_regex CDN exception) succeeds" {
+    # bats test_tags=slow
+    run proxy_logs
+    [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+mintcdn\.com:443 ]]
 }


### PR DESCRIPTION
## Summary
- Adds `docs.anthropic.com` and `code.claude.com` to the Squid Reference tier, plus a `dstdom_regex` exception for `mintcdn.com` — both sites are Mintlify-hosted and serve static assets from that CDN, not from the page domains themselves.
- Extends `test_squid_isolation.bats` with S-4/S-5/S-6 covering the three new allowlist entries.
- Two follow-up fixes surfaced by actually running the suite (see commits): Squid fatally errors when an ACL name is reused with a different acl type, so the regex exception needed its own ACL name; and the curl helper image needed to be fully qualified (`docker.io/curlimages/curl:latest`) since an unqualified reference can resolve against a registry that doesn't carry it, depending on the operator's podman config.

Closes #32

## Test plan
- [x] `bats tests/test_squid_isolation.bats` — all 6 tests pass (verified by the operator; see issue/PR discussion)