### PR TITLE
chore: close fresh-clone and enforcement gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+# ci.yml — the repository's first automated gate.
+#
+# Scope, stated explicitly so nobody mistakes it for more than it is:
+# this job runs ONLY the tests tagged `hostonly` — those that need no
+# container engine and no pre-built image. Today that is the layered-config
+# group (tests/test_config.bats) and the documentation-integrity group
+# (tests/test_docs_integrity.bats).
+#
+# NOT covered here, and still runnable only on a developer machine with
+# Podman and built images:
+#   - tests/test_squid_isolation.bats   (egress policy)
+#   - tests/test_toolchain_smoke.bats   (per-profile toolchains)
+#   - tests/test_global_layer.bats      (global layer injection)
+#   - tests/test_build.bats             (image builds)
+#   - tests/test_runtime_posture.bats   (container runtime flags)
+#
+# That is a deliberate trade, not an oversight: a gate whose scope is
+# documented is a tool, an undocumented one is a trap. Building four images
+# on every push would make this slow and flaky enough that it would end up
+# ignored or disabled, which is worse than a narrow gate that always runs.
+# Extending coverage to the slow tier is a separate decision.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  hostonly:
+    name: Host-only tests (no container engine)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats-core
+        # Upstream install rather than the distro package, matching the
+        # distro-independent instruction in BUILDING.md so CI and a local
+        # run exercise the same bats version semantics.
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          sudo /tmp/bats-core/install.sh /usr/local
+          bats --version
+
+      - name: Guard against an empty test selection
+        # A mistyped or renamed tag makes `--filter-tags` select zero tests
+        # and exit 0 — a green check that asserts nothing, which is exactly
+        # the failure mode this whole workflow exists to prevent elsewhere.
+        run: |
+          count=$(bats --filter-tags hostonly --count tests/)
+          echo "hostonly tests selected: ${count}"
+          if [ "${count}" -eq 0 ]; then
+            echo "::error::No tests matched --filter-tags hostonly; the gate would pass without asserting anything." >&2
+            exit 1
+          fi
+
+      - name: Run host-only tests
+        run: bats --filter-tags hostonly --print-output-on-failure tests/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -244,7 +244,25 @@ bats tests/
 
 # Against the Docker fallback
 ENGINE=docker bats tests/
+
+# Everything that needs no container engine at all — what CI runs
+bats --filter-tags hostonly tests/
 ```
+
+### Tag axes
+
+`fast`/`slow` and `hostonly` are two independent axes, and it is worth not
+confusing them:
+
+| Tag | Means | Example |
+|---|---|---|
+| `fast` | Completes in seconds | `test_global_layer.bats` G-1 — but it still needs a built `claude-base` image |
+| `slow` | Builds images or starts containers | `test_squid_isolation.bats` S-1 |
+| `hostonly` | Needs **no** engine daemon and **no** image | `test_config.bats` C-1, `test_docs_integrity.bats` D-1 |
+
+`fast` does not imply `hostonly`. Several `fast` tests still require a
+running Podman and a pre-built image, which is why CI filters on `hostonly`
+rather than on `fast` — see `.github/workflows/ci.yml`.
 
 See `docs/designs/claude-sandbox-testing-module-sdd.md` for what each test
 group covers and why.

--- a/docs/engineering-principles-by-lifecycle-phase.md
+++ b/docs/engineering-principles-by-lifecycle-phase.md
@@ -1,0 +1,494 @@
+# Engineering Principles by Lifecycle Phase
+
+Extracted from three audits of a family of related production pipelines
+(`architecture-comparison.md`, `guiding-rules-and-enforcement.md`,
+`library-extraction-roadmap.md` — sibling-project documents, not present in
+this repository) and restated so they apply anywhere. The evidence is specific because that is what makes a
+principle memorable; the principle is general because that is what makes it
+portable.
+
+Where a claim in the source documents was checkable against the actual code, it was
+checked. Findings marked *verified* below were confirmed directly.
+
+---
+
+## The habit underneath all of it
+
+One question generated most of what follows:
+
+> **Is this thing load-bearing, or merely present?**
+
+A rule nothing enforces. A test that cannot fail. A feature nothing reads. A green
+CI check on a machine missing the dependency it exists to test. All four look like
+engineering. None of them are. Most of this document is that single question asked
+at a different point in the lifecycle.
+
+## How to read this
+
+Each principle carries four things:
+
+- **Trigger** — what you notice that means it applies
+- **Action** — what to actually do
+- **Prevents** — the failure it insures against
+- **Cheap window** — the phase where doing it is nearly free
+
+The **cheap window** is why this is organized by lifecycle instead of by topic.
+Almost nothing here is technically hard. Most of it is only hard *late*. Dependency
+caps take one line at project setup and a bisection through a major version bump
+afterward. The reasoning behind a rejected design is free to write down the day you
+reject it and unrecoverable six months later. Knowing which window you are in is
+most of the skill.
+
+---
+
+## Part I — Four ideas that cut across every phase
+
+### 1. The enforcement ladder
+
+Every rule sits on a rung. Weakest to strongest:
+
+1. Tribal knowledge — nothing written
+2. Prose in a document (README, wiki, contributing guide)
+3. A comment at the site it governs
+4. Review convention — a human is supposed to catch it
+5. An automated check that can fail the build
+6. A design where violation is unrepresentable — types, API shape, no public setter
+
+**The test:** *if I violate this rule at 2am on a Friday, what stops me?* Answer
+honestly and you have your rung.
+
+Two corollaries matter more than the ladder:
+
+- **Emphasis does not change rungs.** "This is a hard invariant, not a default —
+  re-verify explicitly if you touch this function" is rung 2 no matter how firmly
+  it's phrased. Rung 2 is genuinely better than rung 1. Just know what you bought.
+- **Most rules don't need rung 6.** Deciding a rule stays at rung 2 is a legitimate
+  engineering decision. *Believing* a rung-2 rule is a rung-5 rule is what causes
+  damage — you'll skip the review that was actually holding the line.
+
+*Verified:* all three repos documented `ruff` and `mypy` as the expected local dev
+loop. Zero CI jobs in the family ran either one.
+
+### 2. The fresh-clone test
+
+**Anything not committed to the repo does not exist for the next person.**
+
+Three traps, all verified in the source family:
+
+- A `commit-msg` hook that rejected a forbidden trailer — real, working, and
+  installed by the *environment*, not the repo. Untracked, so it travels with
+  nothing. It looks like enforcement until you run `git ls-files`.
+- Governance that reached two of three repos only through a user-level global config
+  file. A plain `git clone` in a different tool shows no such rule exists.
+- A documented convention citing `docs/angular_commit_convention.md` — a file that
+  was never written.
+
+**Action:** periodically clone into a clean environment, or read `git ls-files`, and
+ask what a newcomer actually sees. Every dangling reference is a rule that has
+already quietly stopped working.
+
+### 3. Load-bearing vs. vestigial
+
+Presence is not function. The family shipped a Spanish email template *and* parsed a
+`language` field into a dataclass — and nothing anywhere read that field to select
+between templates. The capability was complete at every level except the one that
+mattered.
+
+**Action:** to test whether something is real, grep for **readers**, not
+definitions. Better: delete it locally and see what fails. If nothing fails you have
+found either dead weight or a missing test, and both are worth knowing.
+
+Generalizes well past features: feature flags nothing branches on, config keys
+nothing consumes, error types nothing raises, abstract methods with exactly one
+implementation, metrics nothing alerts on.
+
+### 4. Value is knowledge density, not line count
+
+Thirteen lines of COM setup encoded four rejected alternatives and a library
+compatibility patch — knowledge discovered by failure, invisible in a line count.
+Meanwhile roughly 95% of a config module was domain field lists: many lines,
+near-zero knowledge.
+
+**Action:** when deciding what to centralize, protect, test hardest, or comment, ask
+*what does this code know that isn't obvious from reading it?* Code that knows
+things learned the hard way earns one home, real tests, and a note about the paths
+that don't work. Bulk that is merely long earns none of that.
+
+**Consequence:** lines-saved is a bad objective function for refactoring. It
+systematically undervalues the dangerous code and overvalues boilerplate.
+
+**The same test applies to prose, and is failed more often.** A commit message,
+a PR description or a comment earns its length the same way code does — by
+carrying something the reader cannot get from the diff. A rejected alternative
+that looks better than the chosen one. A trap a future cleanup would walk into.
+Everything else is restating what is already visible.
+
+The failure mode is specific: **uniform verbosity destroys the signal that
+verbosity carries.** If every message is long, length stops meaning "this one has
+something in it", and the message that records a real trap gets skimmed with the
+four before it that could have been subject lines. Padding does not merely waste
+the reader's time; it spends the attention the important message needed. This is
+the same shape as a gate that cannot fail, or a test that cannot catch a change —
+a signal that is always on is not a signal.
+
+**Action:** default to the shortest form that works — subject only, no comment,
+no description. Spend length when the diff genuinely cannot carry the reason, and
+spend it there only. And calibrate to the actual reader: an explanation written
+for reviewers who lack context is worth little when the reviewer is the person
+who asked for the work.
+
+---
+
+## Part II — By lifecycle phase
+
+### Inception & setup
+
+The cheapest phase in the lifecycle and the one most often skipped, because nothing
+feels at risk yet. Everything here costs minutes now and days later.
+
+**Cap your dependencies.** `pandas>=2.0.0` with no upper bound and no lockfile
+resolved, in live virtual environments, to pandas 3.0.3 — a major version the code
+was never written against (*verified*). Pin an upper bound or commit a lockfile on
+day one. Retrofitting after a silent major bump means bisecting behavior changes
+with no known-good baseline to bisect against.
+
+**Declare one runtime version and make every surface agree.** In the family:
+`requirements.txt` said "Tested on Python 3.9+", `pyproject.toml` said `>=3.11`, one
+CI ran 3.12, another ran 3.11 (*verified*). Four sources, three answers.
+Contradictory version claims are how "works on my machine" becomes structural rather
+than anecdotal.
+
+**Stand up CI before there is anything to run in it.** A repo that ships without CI
+rarely gains it later — one of the three never did, and its absence became a
+blocking prerequisite in a roadmap written a year on. Adding CI to a young repo is a
+chore. Adding it to a mature one means confronting every accumulated failure at once,
+which is why it doesn't happen.
+
+**Put governance in the repo, not in your environment.** See the fresh-clone test.
+
+**Keep machine-specific build artifacts out of shared trees.** A virtualenv,
+`node_modules`, a compiled cache — each records absolute paths from the machine
+that created it. Put one inside a directory that is bind-mounted, synced, or
+network-shared between two machines and it can only ever be correct for one of
+them.
+
+The failure mode is what makes this worth a principle rather than a footnote.
+Repairing the artifact on one machine rewrites those paths and breaks the other.
+Each repair genuinely succeeds for whoever ran it, so nobody sees a contradiction
+— it presents as *flakiness* ("the environment keeps breaking") rather than as
+two consumers of one artifact that cannot serve both. Two people running the same
+repair tool will alternate which side is broken, indefinitely, each convinced
+they fixed it.
+
+**Action:** before repairing anything that "keeps breaking", establish how the
+directory is shared — `/proc/mounts`, or your sync tool's configuration. A bind
+mount (one copy, two names) and a sync tool (two copies kept in step) look
+identical from a single shell and need opposite remedies. Then give each machine
+its own copy of the artifact by *masking the path per-machine* rather than
+relocating it, so shared scripts and documentation keep working unchanged.
+
+**Cheap window:** when you decide where the artifact lives. Afterwards it costs a
+diagnosis session per affected machine, and the diagnosis is unusually hard
+because every individual observation looks like success.
+
+### Design
+
+**Record rejections, not just decisions.** The most valuable ADR in the family
+documents four *failed* approaches to injecting an email signature through COM. Its
+worth isn't the decision it reached — it's the four paths a future engineer no
+longer has to walk. A second repo recorded an idea as explicitly declined, so it
+could not be re-litigated from scratch by the next person who found it obvious.
+
+A format that works:
+
+> **Chose:** … **Rejected:** … **Why the rejected option is attractive:** … **What
+> breaks if you try it anyway:** …
+
+That third line is the one people skip and the one that does the work. An option
+recorded without its appeal will simply be reinvented.
+
+*Cheap window: the moment of decision.* The reasoning evaporates in weeks. Nobody
+successfully reconstructs "why didn't we just…" a year later.
+
+**Name the anti-pattern, not only the rule.** "This function stays a display
+formatter, never a rounding authority — anything needing other precision must arrive
+already rounded," plus a pointer to the specific bug that prompted it, is durable in
+a way "round consistently" is not. Rules written by someone who has been burned once
+read differently, and they survive longer.
+
+**Name your anti-goals.** The strongest roadmap in the family has an explicit
+"Explicitly not a phase" section. Stating what you are deliberately *not* doing, and
+why, controls scope better than silence — because silence reads as "not yet."
+
+**Put a human in the loop on irreversible actions.** Every pipeline in the family
+composes an email draft and calls `.Save()`. None call `.Send()`. The invariant
+isn't "be careful" — it's that the irreversible call does not appear in the codebase
+at all. Generalizes to deletes, migrations, payments, outbound notifications, and
+anything that reaches a customer: make the destructive path require a separate,
+deliberate act rather than a correct parameter.
+
+**Prefer narrowing to accumulating.** Each generation of the family deliberately
+*shed* generality it didn't need — dropped attachment support, collapsed its CLI to
+two flags, removed an entire export module — while adding one narrow correctness
+mechanism. Removal is a design outcome, not a failure to be sufficiently general.
+
+### Implementation
+
+**Validate at the boundary; fail loud and early.** Check every expected input field
+up front and report the missing name, rather than dying with a `KeyError` deep in a
+transform three hundred lines later. The error should name the thing and appear at
+ingestion.
+
+**Route bad data; don't drop it and don't crash on it.** All three repos send
+unparseable rows to a dedicated error export. The run completes, the problem is
+visible, nothing is silently lost. That is the difference between a system that
+degrades and one that fails whole — and between a bug you find today and one you
+find in a quarterly reconciliation.
+
+**No string literals for external names in logic.** Every source column name is a
+config field. When upstream renames a header you edit one line, not fifteen call
+sites — and a typo is caught by the boundary validator instead of at runtime.
+
+**Inject the clock.** Every date-dependent function takes `today: date | None =
+None`. Ambient time is the most common untestable dependency in ordinary business
+code and the fix costs one parameter. Same treatment for randomness, UUIDs,
+filesystem roots, and network clients.
+
+**Use presence-based checks, not truthiness, wherever absence and emptiness
+differ.** `style["font"] if "font" in style else default` honors an explicit `""` as
+"no font." `style.get("font") or default` silently overrides the user. Every config
+layer, override mechanism, and merge function has this bug latent in it, and it
+surfaces as "the system ignores my setting" — reported by users, never by tests.
+
+**Get backward compatibility by construction where you can.** Adding new options as
+keyword-only parameters, each defaulting to the exact literal that was previously
+hardcoded, makes "existing callers get byte-identical output" a property you can
+*see* in the signature rather than one you have to test for. Prefer designs where
+the compatibility claim is structural.
+
+### Verification
+
+The phase where the source family was weakest, which makes these the sharpest
+findings in the set.
+
+**Test count is not test strength.** One repo carried 228 tests and asserted that a
+generated chart was `bytes` beginning with the PNG magic number — a completely wrong
+chart passes. Another asserted only that the substring `"Category"` appeared in the
+rendered HTML. A refactor changing whitespace, tag order, attribute order, column
+order, or row striping would have passed all three suites cleanly.
+
+**Know your assertion ladder:**
+
+| Rung | Assertion | Catches |
+|---|---|---|
+| 1 | It ran without raising | Crashes |
+| 2 | A substring appears | Gross omission |
+| 3 | A structural property holds | Shape errors |
+| 4 | An exact fragment matches | Local regressions |
+| 5 | The whole artifact matches a stored reference | Anything that changed |
+
+Every rung is legitimate. The failure is believing you're higher than you are.
+Write down, explicitly, what your suite would *not* catch.
+
+**Characterization tests are a precondition for refactoring, not a nice-to-have.**
+If you cannot detect the output changing, you cannot refactor the code that produces
+it — you can only hope. Pin current output *before* touching anything, even when
+the current output has known bugs: you are pinning behavior, not blessing it. Then
+every intentional change shows up as a deliberate diff to a reference file, which is
+exactly the review you want.
+
+**Codify incidents into tests.** The family's one serious output-corruption incident
+was diagnosed by manually diffing XML against real Excel, fixed, and written up as a
+postmortem — and never turned into a test. The postmortem is good practice. Stopping
+there means the same class of bug is still undetectable today.
+
+> A postmortem without a regression test is a story, not a control.
+
+**Verify that your gate can fail.** A CI job ran end-to-end Outlook tests on a
+runner with no Outlook installed — the job's own inline comment admits it
+(*verified*). It passed on every pull request, meaninglessly. Once, deliberately
+break the thing a check protects and confirm the check goes red. **A gate never
+observed failing is not known to be a gate.**
+
+**Excluded-by-default suites need an owner and a trigger.** All three repos excluded
+their COM/Office tests by default and documented "run manually before a release."
+Nothing anywhere automates that (*verified*). That is an honor system, which is a
+fine thing to choose deliberately and a dangerous thing to mistake for a gate.
+
+### Release & deployment
+
+**Smoke-test the launcher, not just the application.** A ~17-line flag that checks
+only that the virtual environment resolves, exits 0 or 1, and is wired into CI. It
+catches the "deployment is broken in a way no unit test can see" class of failure
+for almost nothing.
+
+**Count your deployment multiplicities before proposing shared code.** Three
+independent checkouts, three virtual environments, editable installs by path: one
+library change means three pulls and three reinstalls, and an editable path install
+breaks silently if the directories aren't laid out as siblings. That recurring cost
+is what any one-time savings has to beat.
+
+**Server-side controls are part of the system and are invisible in the repo.** No
+CODEOWNERS, no branch protection as code, no required status checks anywhere in the
+family — so even where CI ran, nothing forced it to pass before a merge. Enforcement
+that lives only in a web console is unreviewed, unversioned, and unrestorable. Check
+it explicitly; prefer config-as-code wherever the platform allows it.
+
+### Operations & maintenance
+
+**Enumerate every side effect before claiming idempotency.** The family's outputs
+were described as "naturally idempotent — dated, overwritable files." True of the
+files, false of the system: each run also created a draft in a mail client over COM,
+so a rerun produced a *second* duplicate draft. Overwriting a file protects the
+file, not the mailbox.
+
+> Idempotency is a per-effect property, not a per-run one — and the unprotected
+> effect is usually the one that reaches a human.
+
+List every externally visible effect of a run — files, emails, database rows,
+webhooks, notifications, ticket comments — and check them one at a time.
+
+**Give bypass flags an explicit contract.** One repo's `--force-compose`
+deliberately bypasses two independent guards at once and says exactly that in its
+help text. A bypass whose scope is documented is a tool; an undocumented one is a
+trap that someone will spring during an incident.
+
+**Derive dedup keys from content, and write them only after success.** A stable key
+built from the fields that define "the same notification," checked against an
+append-only log, appended *only after* the side effect actually succeeded. The
+ordering is the whole design: log before success and a mid-run crash permanently
+suppresses a real notification.
+
+### Evolution — refactoring, extraction, reuse
+
+The richest phase, and the one with the most counterintuitive findings.
+
+**Measure before extracting; classify, don't eyeball.** Diff each candidate across
+consumers and label it: byte-identical / cosmetic only / minor behavioral drift /
+genuinely different. This takes an afternoon and routinely inverts your intuitions.
+
+**Extract what has converged, not what looks similar.** The single most transferable
+sentence in the source material. The function that looked most obviously shared — an
+HTML table renderer present in all three repos — was the *worst* candidate. Each
+consumer had grown a different **extension axis** over a ~12-line skeleton: one a
+styling callback plus row truncation, one seven keyword-only style parameters plus a
+column subset, one no extension point at all. Three incompatible extension models is
+not shared code wearing three hats. It is three functions with a similar silhouette.
+
+The diagnostic generalizes, and it's visible *before* you commit:
+
+> The pieces that stayed extractable are the ones nobody needed to extend.
+> Divergent extension points are the reliable signal that a shared abstraction will
+> fail.
+
+**Be honest about ROI, then relocate the argument.** Measured purely as
+deduplication, the extraction saved ~3% net — not worth a new repository, a
+distribution channel, and three-way version coordination. Publishing that number
+didn't kill the project; it moved the justification to where it was actually strong:
+change propagation (one home for hard-won platform knowledge) and time-to-build-the-
+next-one. If your headline metric doesn't justify the work, say so out loud and find
+the real reason — or stop.
+
+**Separate "best implementation" from "safest to touch first."** The most
+generalized version of every candidate lived in the newest repo, which was also the
+least safe to migrate: no CI, no virtual environment, thinnest assertions, and a
+live client pilot. Correct answer: seed the shared library *from* it, migrate it
+*last*. These are different axes, and conflating them is how migrations end up
+starting with the riskiest consumer.
+
+**Sequence so early work isn't wasted if you abandon.** The roadmap's Phase 0 was
+golden tests, CI, lint enforcement, and dependency caps — every item valuable
+standalone. If the library is never built, none of it is wasted. Front-load work
+whose value doesn't depend on the project completing.
+
+**Build scaffolding last.** A project template generated before the API has survived
+real migrations bakes in guesses. Templates encode assumptions permanently and
+cheaply, which is precisely why they belong after the assumptions have been tested.
+
+**Don't converge architectures as a prerequisite.** Reshaping working systems toward
+a common shape spends the most refactoring risk of any available work while
+producing nothing shippable — and erases divergences that were often deliberate and
+documented. Convergence is a *side effect* of adoption where extraction forces it,
+not a phase you schedule.
+
+**Distinguish porting a capability from converging a design.** Moving a
+self-contained, independently valuable feature into another codebase is cheap,
+additive, and revertible. Reshaping a codebase to resemble its siblings is none of
+those three. The two get confused constantly, and the confusion always runs in the
+expensive direction.
+
+---
+
+## Part III — Patterns worth stealing verbatim
+
+| Pattern | Shape | Pays off when |
+|---|---|---|
+| Layered config precedence | `defaults ← committed file ← local override ← CLI flags`, each layer partial | Environments differ but the schema doesn't |
+| Boundary validation | One `validate_inputs()` mapping field → expected name, called before any transform | Inputs come from outside your control |
+| Error-row routing | Bad records to a dedicated export; run completes | Partial success beats total failure |
+| Injectable `today` | `def f(..., today: date \| None = None)` | Anything date-dependent, i.e. most business logic |
+| Keyword-only additive params | New options keyword-only, defaulting to the old hardcoded literal | Extending a function with existing callers |
+| Presence-based merge | `d["k"] if "k" in d else fallback` | Any override layer where empty ≠ absent |
+| Append-only dedup log | Content-derived key, written after success | Any effect that can't be safely repeated |
+| Launcher smoke test | Verify the entry point resolves; exit 0/1; run in CI | Deployment differs from development |
+| ADR with rejections | Chose / rejected / why it's attractive / what breaks | Any non-obvious decision |
+| Postmortem → regression test | Every incident writeup ends in a failing-then-passing test | Always |
+
+---
+
+## Part IV — Smell catalogue
+
+| You observe | Suspect | Check it with |
+|---|---|---|
+| A doc cites another doc | The target doesn't exist | Open the path |
+| A rule stated emphatically | Nothing enforces it | Grep CI config for the command |
+| A green CI job | It passes trivially | Read the job's own comments; confirm its dependency is installed |
+| A high test count | Weak assertions | Read the tests for the most complex output |
+| A postmortem | No regression test exists | Search tests for the incident's keywords |
+| A hook in `.git/hooks` | Untracked, or installed by tooling | `git ls-files`; read the header comment |
+| Two files that look alike | Different extension axes | Diff them; list each one's parameters |
+| A `>=` dependency with no cap | Already resolved past a major version | Compare declared vs. installed |
+| A config key, flag, or template | Nothing reads it | Grep for readers, not definitions |
+| "It's idempotent" | Only one of its side effects is | Enumerate every externally visible effect |
+| A version claimed in several places | They disagree | Grep all of them at once |
+| A manual pre-release step | Nothing triggers it | Search automation for the command |
+| Every commit message is long | Length no longer marks the ones that matter | Check whether the last five bodies could have been subjects |
+| A fix that has to be reapplied | Two consumers of one artifact, not a flaky fix | Establish how the directory is shared: `/proc/mounts`, sync-tool config |
+| Two people report opposite results from one directory | It is one directory under two paths | Compare absolute paths; check for a bind mount |
+
+---
+
+## Part V — An audit protocol for an unfamiliar codebase
+
+Ordered so that each step is cheap and the early ones inform the later ones.
+
+1. `git ls-files` — establish what actually ships, before reading anything.
+2. Read the CI configuration end to end and list every command it runs. List every
+   command the docs say to run. **The difference is your enforcement gap.**
+3. For each gate, ask what would make it fail. Any gate you can't answer for,
+   treat as decorative until proven otherwise.
+4. Read the most complex output-producing function, then read its tests. Write down
+   what a refactor could change without failing anything.
+5. Grep for dependency specs with no upper bound; compare declared against installed.
+6. Grep every place a language or runtime version is claimed. They should agree.
+7. Follow every documentation cross-reference and confirm the target exists.
+8. Pick three config keys, flags, or templates and grep for **readers**.
+9. Enumerate the side effects of one run; ask which are individually idempotent.
+10. Read the ADRs and postmortems; for each, check whether a test encodes it.
+
+Steps 2 and 3 are the highest yield in almost every codebase, and take under an hour.
+
+---
+
+## The one-sentence version
+
+**Ask what's load-bearing, act inside the cheap window, and prefer mechanisms to
+intentions.**
+
+The source family's own trajectory is the cautionary tale the rest of this document
+is built around: across three generations, documentation rigor rose steadily while
+enforcement stayed flat at roughly zero. Each generation wrote its rules more
+precisely than the last rather than building anything that made them stick. Writing
+rules precisely is a real improvement and worth doing — and it is not a substitute
+for making them mechanical. A rule a reader cannot misunderstand is still a rule a
+reader can ignore.

--- a/docs/sdlc_reference_guide.md
+++ b/docs/sdlc_reference_guide.md
@@ -1,0 +1,335 @@
+# Software Development Life Cycle (SDLC) — Reference Guide
+
+> **Scope:** A concise but complete reference covering the history, phases, professionals, artifacts, and vocabulary of the SDLC. Intended as a portable companion document for software engineering projects.
+
+---
+
+## Table of Contents
+
+1. [Historical Context](#1-historical-context)
+2. [The Seven Phases](#2-the-seven-phases)
+   - 2.1 [Planning](#21-planning)
+   - 2.2 [Requirements Analysis](#22-requirements-analysis)
+   - 2.3 [System Design](#23-system-design)
+   - 2.4 [Development](#24-development)
+   - 2.5 [Testing & Quality Assurance](#25-testing--quality-assurance)
+   - 2.6 [Deployment](#26-deployment)
+   - 2.7 [Maintenance & Operations](#27-maintenance--operations)
+3. [Phase Summary Table](#3-phase-summary-table)
+4. [Cycle Diagram](#4-cycle-diagram)
+5. [Methodological Notes](#5-methodological-notes)
+6. [Glossary](#6-glossary)
+7. [References & Further Reading](#7-references--further-reading)
+
+---
+
+## 1. Historical Context
+
+The concept of a structured software life cycle emerged in the **1950s and 1960s**, when organizations needed repeatable processes for building large data-processing systems on mainframes. Without structure, software projects were delivered late, over budget, or not at all — a problem later named the **Software Crisis** at the 1968 NATO Software Engineering Conference in Garmisch, Germany.
+
+The most influential early document is Winston Royce's 1970 paper *"Managing the Development of Large Software Systems"*. It is historically ironic: Royce presented a sequential model only to argue *against* it, writing explicitly that "the implementation described above is risky and invites failure." He advocated for iterative passes through the development cycle. Nevertheless, the sequential reading of his model became the dominant paradigm for the next three decades. The term **waterfall** was never used by Royce; it was introduced by Bell and Thayer in 1976.
+
+Key milestones in SDLC history:
+
+| Year | Event |
+|------|-------|
+| 1968 | NATO Software Engineering Conference defines the Software Crisis |
+| 1970 | Royce publishes the paper later misread as the Waterfall model |
+| 1976 | Bell & Thayer coin the term "waterfall" |
+| 1986 | Barry Boehm introduces the Spiral Model, explicitly iterative |
+| 1995 | Scrum framework published by Sutherland & Schwaber |
+| 2001 | Agile Manifesto published at Snowbird, Utah, by 17 practitioners |
+| 2008–present | DevOps movement blurs the line between deployment and maintenance |
+
+Today, the **phases** of the SDLC are broadly stable and recognized across methodologies. What varies is *how* the phases are sequenced (once in Waterfall, repeatedly in Agile/Scrum, concurrently in DevOps).
+
+---
+
+## 2. The Seven Phases
+
+### 2.1 Planning
+
+**Initiated by:** A business need, strategic opportunity, regulatory requirement, or executive directive.
+
+**Objective:** Establish whether the project is worth pursuing. Define scope, high-level timeline, resource requirements, cost estimates, and risk profile. The output of this phase is a *go/no-go* decision.
+
+**Responsible professionals:**
+- Project Manager (PM)
+- Business Analysts
+- Product leadership / C-suite sponsors
+- Financial controllers
+
+**Output artifacts:**
+- Project Charter
+- Feasibility Study (technical, operational, financial)
+- Risk Assessment
+- High-level Project Plan
+- Budget estimate
+
+**Destination:** If approved → Requirements Analysis. If unfeasible or deprioritized → project is shelved or redesigned. For major new versions of an existing system, Maintenance loops back here.
+
+---
+
+### 2.2 Requirements Analysis
+
+**Initiated by:** Approval of the Project Charter from Phase 1.
+
+**Objective:** Elicit, document, and validate *what* the system must do (functional requirements) and *how* it must perform (non-functional requirements: performance, security, availability, scalability). Requirements must be unambiguous, measurable, and traceable.
+
+**Responsible professionals:**
+- Business Analysts (BA)
+- Systems Analysts
+- Product Owner (PO)
+- Domain experts and end-user representatives
+
+**Output artifacts:**
+- Software Requirements Specification (SRS)
+- Use Case documents or User Stories (depending on methodology)
+- Requirements Traceability Matrix (RTM)
+
+**Destination:** Signed-off SRS → System Design. Ambiguous or conflicting requirements loop back within this phase until stakeholders reach consensus.
+
+---
+
+### 2.3 System Design
+
+**Initiated by:** A baselined, approved SRS.
+
+**Objective:** Translate requirements into a concrete technical blueprint. Covers system architecture, database schema, API contracts, UI/UX wireframes, infrastructure topology, and security model. Typically split into High-Level Design (HLD) and Low-Level Design (LLD).
+
+**Responsible professionals:**
+- Software Architects
+- Senior / Lead Engineers
+- UX Designers
+- Database Administrators (DBA)
+- Security Engineers
+
+**Output artifacts:**
+- Design Document Specification (DDS)
+- High-Level Design (HLD): component overview, technology stack, integration points
+- Low-Level Design (LLD): class diagrams, data models, algorithm specifications
+- UI/UX wireframes and prototypes
+
+**Destination:** Approved DDS → Development. Designs that reveal requirement gaps or fail technical review return to Requirements Analysis.
+
+---
+
+### 2.4 Development
+
+**Initiated by:** Approved DDS and, in Agile, a prioritized sprint backlog.
+
+**Objective:** Write, review, and integrate the source code that implements the design. Engineers build individual components, modules, or functions, verify they work in isolation (unit tests), and integrate them progressively.
+
+**Responsible professionals:**
+- Software Engineers (frontend, backend, mobile, embedded)
+- Technical Lead
+- DevOps Engineers
+- Database Developers
+
+**Output artifacts:**
+- Source code (version-controlled)
+- Compiled builds / binaries
+- Unit tests and test results
+- Code review records
+- Internal (inline) documentation
+
+**Destination:** Completed, reviewed build → Testing. Code failing peer review or failing to integrate → returned to Development for rework.
+
+---
+
+### 2.5 Testing & Quality Assurance
+
+**Initiated by:** A stable build delivered from Development.
+
+**Objective:** Verify the software meets all requirements (functional and non-functional), locate and fix defects, and validate security, performance, and usability before release. Includes unit, integration, system, regression, performance, security, and user acceptance testing (UAT).
+
+**Responsible professionals:**
+- QA Engineers / Test Analysts
+- Performance Engineers
+- Security Testers (penetration testers)
+- End users (for UAT)
+
+**Output artifacts:**
+- Test Plan and Test Cases
+- Bug Reports / Defect Log
+- Test Summary Report (outcome, defect status, release readiness)
+
+**Destination:** All acceptance criteria met → Deployment. Critical defects → build returned to Development. In regulated industries, a formal audit sign-off is required before proceeding.
+
+---
+
+### 2.6 Deployment
+
+**Initiated by:** A test-approved build and release authorization from the Release Manager and stakeholders.
+
+**Objective:** Deliver the software into the production environment and integrate it into users' daily workflows. Covers installation, configuration, user notification, training, and cutover from any legacy system. The phase is complete when the system operates in production in accordance with defined requirements.
+
+**Responsible professionals:**
+- Release Manager
+- DevOps / Release Engineers
+- System Administrators
+- Change Management team
+- Training specialists
+
+**Output artifacts:**
+- Deployed production system
+- Deployment Runbook (step-by-step execution guide)
+- Rollback Plan
+- User training materials
+- Release Notes
+
+**Destination:** Successful go-live → Maintenance. Critical production failure → rollback, return to Testing or Development.
+
+---
+
+### 2.7 Maintenance & Operations
+
+**Initiated by:** System going live in production.
+
+**Objective:** Sustain correct, secure, and efficient operation over the system's operational lifespan. Encompasses bug fixes, security patches, performance optimizations, and feature enhancements driven by user feedback and changing business needs.
+
+**Responsible professionals:**
+- Software Maintenance Team
+- Release Manager (for subsequent releases)
+- Support / Operations Team
+- End Users (as source of feedback and change requests)
+
+**Output artifacts:**
+- Patch releases
+- Updated documentation
+- Incident and post-mortem reports
+- Performance metrics dashboards
+- Change Requests (feeding back into the cycle)
+
+**Destination:**
+- Minor fixes → Development → Testing → Deployment
+- New significant features → Planning or Requirements Analysis (new cycle begins)
+
+---
+
+## 3. Phase Summary Table
+
+| Phase | Initiated by | Objective | Responsible professionals | Key output artifacts | Destination |
+|---|---|---|---|---|---|
+| **1. Planning** | Business need or strategic directive | Scope, feasibility, go/no-go decision | PM, BA, Product leadership, Finance | Project Charter, Feasibility Study, Risk Assessment, Project Plan | Approved → Requirements; Rejected → shelved |
+| **2. Requirements Analysis** | Approved Project Charter | Document what the system must do and how it must perform | BA, Systems Analyst, PO, Domain experts | SRS, Use Cases / User Stories, RTM | Signed-off SRS → Design; Gaps found → loop within phase |
+| **3. System Design** | Baselined SRS | Translate requirements into a technical blueprint | Architects, Lead Engineers, UX Designers, DBA, Security | DDS (HLD + LLD), wireframes | Approved DDS → Development; Gaps → Requirements Analysis |
+| **4. Development** | Approved DDS / sprint backlog | Build and integrate the source code | Software Engineers, Tech Lead, DevOps | Source code, builds, unit tests, code review records | Reviewed build → Testing; Review failure → rework |
+| **5. Testing & QA** | Stable build from Development | Verify requirements, find defects, validate quality | QA Engineers, Security Testers, Performance Engineers, End Users (UAT) | Test Plan, Bug Reports, Test Summary Report | Criteria met → Deployment; Critical defects → Development |
+| **6. Deployment** | Test-approved build + release authorization | Deliver software to production; integrate into workflows | Release Manager, DevOps, SysAdmins, Change Mgmt, Trainers | Deployed system, Runbook, Rollback Plan, Release Notes, Training materials | Success → Maintenance; Failure → rollback → Testing / Development |
+| **7. Maintenance & Operations** | System live in production | Sustain and evolve the system over its lifespan | Maintenance Team, Release Manager, Support, End Users | Patches, updated docs, incident reports, metrics, Change Requests | Minor fix → Development; Major new version → Planning |
+
+---
+
+## 4. Cycle Diagram
+
+The diagram below illustrates the primary flow (top-to-bottom) and the principal feedback loops. Left-side loops represent in-cycle corrections; the right-side loop represents the restart of a new version cycle from Maintenance.
+
+> **Compatibility note:** Rendered as a Mermaid diagram. Supported natively in Obsidian, GitHub, GitLab, and VS Code (with the Markdown Preview Mermaid Support extension). For other renderers, the [Mermaid Live Editor](https://mermaid.live) can export the block as PNG or SVG.
+
+```mermaid
+flowchart TD
+    P1["**1 · Planning**\nScope · feasibility · go/no-go · budget"]
+    P2["**2 · Requirements Analysis**\nSRS · use cases · RTM"]
+    P3["**3 · System Design**\nArchitecture · HLD · LLD · UI/UX · security"]
+    P4["**4 · Development**\nSource code · builds · unit tests · reviews"]
+    P5["**5 · Testing & QA**\nBug reports · test summary · UAT"]
+    P6["**6 · Deployment**\nRelease · training · go-live · runbook"]
+    P7["**7 · Maintenance & Operations**\nPatches · enhancements · monitoring"]
+
+    P1 --> P2
+    P2 --> P3
+    P3 --> P4
+    P4 --> P5
+    P5 --> P6
+    P6 --> P7
+
+    P3 -- "Req. gap" --> P2
+    P5 -- "Defects" --> P4
+    P6 -- "Rollback" --> P5
+    P7 -. "Minor fix" .-> P4
+    P7 -- "New version" --> P1
+
+    style P1 fill:#e8d5f5,stroke:#7c4daa,color:#1a1a1a
+    style P2 fill:#d0eef8,stroke:#2980b9,color:#1a1a1a
+    style P3 fill:#d0eef8,stroke:#2980b9,color:#1a1a1a
+    style P4 fill:#fde8e0,stroke:#c0392b,color:#1a1a1a
+    style P5 fill:#fef3cd,stroke:#d68910,color:#1a1a1a
+    style P6 fill:#fde8e0,stroke:#c0392b,color:#1a1a1a
+    style P7 fill:#e8d5f5,stroke:#7c4daa,color:#1a1a1a
+```
+
+---
+
+## 5. Methodological Notes
+
+The phases described above are methodology-agnostic. The key differences between approaches lie in *sequencing and iteration*, not in which phases exist.
+
+| Methodology | Phase execution pattern | Key trait |
+|---|---|---|
+| **Waterfall** | Sequential, once | Strict phase gates; low tolerance for change |
+| **Spiral** | Sequential, iterative with risk analysis per loop | Risk-driven; common in large government/defense projects |
+| **Scrum (Agile)** | All phases compressed into 1–4 week sprints | Embraces changing requirements; team-centric |
+| **Kanban (Agile)** | Continuous flow; no fixed sprints | Optimizes throughput; visualizes WIP limits |
+| **DevOps** | Dev + Ops merged; CD pipeline automates deploy/maintain | Collapses phases 6 & 7 into a continuous delivery loop |
+| **SAFe** | Agile scaled to enterprise; multiple teams, synchronized PI | Large organizations with many parallel tracks |
+
+In practice, most modern organizations use a **hybrid**: Agile sprints for development with Waterfall-style gate reviews for architecture and compliance.
+
+---
+
+## 6. Glossary
+
+| Term | Definition |
+|---|---|
+| **Artifact** | A formally produced document or deliverable associated with a specific SDLC phase (e.g., SRS, DDS, Test Plan). |
+| **Backlog** | An ordered list of work items (features, bugs, tasks) to be addressed in future sprints; core to Scrum. |
+| **Baseline** | A snapshot of an artifact formally approved and placed under change control; subsequent changes require a formal request. |
+| **Change Request (CR)** | A formal proposal to modify an already-baselined artifact or deployed system. |
+| **CI/CD** | Continuous Integration / Continuous Delivery — automated pipelines that build, test, and deploy code on every commit. |
+| **DDS** | Design Document Specification. Comprises the HLD and LLD, describing how the system will be built. |
+| **DevOps** | A culture and set of practices merging software development (Dev) and IT operations (Ops) to shorten delivery cycles. |
+| **Feasibility Study** | A pre-project assessment of whether a proposed system is technically, operationally, and financially viable. |
+| **HLD** | High-Level Design. Describes the system's components, their responsibilities, and how they interact — without implementation detail. |
+| **LLD** | Low-Level Design. Detailed, implementation-ready specification: class diagrams, data models, algorithms. |
+| **Non-functional requirement** | A constraint on *how* the system performs, rather than *what* it does (e.g., response time < 200 ms, 99.9% uptime). |
+| **PO** | Product Owner. Represents stakeholder interests in Agile teams; owns and prioritizes the backlog. |
+| **Post-mortem** | A structured review conducted after a production incident or project phase to identify root causes and improvements. |
+| **Rollback Plan** | A documented procedure to revert a deployment to the previous stable state if a critical failure occurs. |
+| **RTM** | Requirements Traceability Matrix. Maps each requirement to its design, implementation, and test coverage. |
+| **Runbook** | Step-by-step operational instructions for executing a deployment or responding to a production incident. |
+| **SDLC** | Software Development Life Cycle. The structured process governing how software is conceived, built, released, and retired. |
+| **Sprint** | A fixed-length iteration (typically 1–4 weeks) in Scrum during which a defined set of backlog items is completed. |
+| **SRS** | Software Requirements Specification. The primary output of the Requirements Analysis phase; defines what the system must do. |
+| **UAT** | User Acceptance Testing. Validation performed by end users or their representatives to confirm the system meets business needs before go-live. |
+| **WIP** | Work In Progress. The number of tasks currently being worked on; limiting WIP is a core Kanban principle. |
+
+---
+
+## 7. References & Further Reading
+
+### Primary sources
+
+- Royce, W. W. (1970). *Managing the Development of Large Software Systems.* Proceedings of IEEE WESCON, 26, 1–9. — The foundational paper, often misread as a Waterfall endorsement.
+- Beck, K., et al. (2001). *Manifesto for Agile Software Development.* [https://agilemanifesto.org](https://agilemanifesto.org)
+- Boehm, B. W. (1988). *A Spiral Model of Software Development and Enhancement.* IEEE Computer, 21(5), 61–72.
+- NATO Science Committee (1968). *Software Engineering: Report on a conference sponsored by the NATO Science Committee, Garmisch, Germany.* — The conference that named the Software Crisis.
+
+### Standards and frameworks
+
+- **IEEE Std 12207-2017** — Systems and Software Engineering: Software Life Cycle Processes. The definitive international standard.
+- **ISO/IEC/IEEE 29148:2018** — Requirements Engineering. Defines best practices for the Requirements Analysis phase.
+- **NIST SP 800-64** — Security Considerations in the System Development Life Cycle. Integrates security into each SDLC phase.
+- **PMBOK® Guide** (7th ed., 2021) — Project Management Body of Knowledge. Project Management Institute.
+
+### Recommended reading
+
+- Pressman, R. S., & Maxim, B. R. (2020). *Software Engineering: A Practitioner's Approach* (9th ed.). McGraw-Hill. — Standard university reference; covers all SDLC phases in depth.
+- Sommerville, I. (2016). *Software Engineering* (10th ed.). Pearson. — Another comprehensive academic reference with strong coverage of requirements and design.
+- Kim, G., Humble, J., Debois, P., & Willis, J. (2016). *The DevOps Handbook.* IT Revolution Press. — Practical guide to collapsing the deployment/maintenance boundary.
+- Cohn, M. (2004). *User Stories Applied.* Addison-Wesley. — Definitive reference for Agile requirements in the form of user stories.
+- Brooks, F. P. (1975, revised 1995). *The Mythical Man-Month.* Addison-Wesley. — Classic essays on software project management; still deeply relevant.
+
+---
+
+*Document version 1.0 — Compiled June 2026*

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -71,8 +71,8 @@ Two options, covered in detail in `ARCHITECTURE.md`:
   at session start** — usually means a venv or CMake build directory in
   your project was built against a tool installed via Strategy B that was
   never promoted to the Dockerfile. The warning names the fix. Background:
-  [`interpreter-presence-health-check.md`](../interpreter-presence-health-check.md),
-  [`workspace-artifact-staleness.md`](../workspace-artifact-staleness.md).
+  [`interpreter-presence-health-check.md`](designs/interpreter-presence-health-check.md),
+  [`workspace-artifact-staleness.md`](designs/workspace-artifact-staleness.md).
 - **Session start fails with "unknown image" or "image does not exist"** —
   check the profile name is one of `base`/`crypto`/`systems`/`research`,
   and that you've built it with `./build.sh <profile>`.

--- a/global-claude/skills/industry-research-analyst/SKILL.md
+++ b/global-claude/skills/industry-research-analyst/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: industry-research-analyst
+description: "Professional industry/tech research: landscape overviews, market analysis, deep dives. Trigger on any request to research, analyze, investigate, or deep-dive a company, market, or technology."
+---
+
+# Industry & Technology Research Analyst
+
+Act as a professional research analyst specializing in industry and technology. Combine analytical rigor with practical relevance, grounded in current, verifiable information.
+
+## Workflow
+
+Follow these steps, in order, for every research request:
+
+1. **Landscape first.** Open with a concise, informal overview: key players, relevant context, existing tensions, open questions. Direct and conversational — this is not yet the formal report.
+
+2. **Scope check.** If the topic itself is broad/ambiguous, or if region/market/time frame is unclear *and plausibly relevant* (e.g. market sizing, regulation, consumer behavior, competitive presence in specific markets), ask ONE consolidated scoping question covering whatever is unclear. Never ask more than one question, and never split scope questions across turns. Do NOT ask about region when the topic is inherently global or region-agnostic (e.g. a single company's overall strategy, a technology's technical merits, a global industry trend) — treat that as reasonably implied, not ambiguous. If everything needed is already clear, skip this step.
+
+3. **Research brief.** Before the full research, present a short methodology note: the angle you'll take, the source types you'll draw from, the defined scope (including region, if applicable), and what you're intentionally leaving out.
+
+4. **Structured research.** Deliver the in-depth research. Surface well-organized, evidence-rich information. Avoid editorializing or premature conclusions — offer conclusions/recommendations only when explicitly requested.
+
+5. **Follow-ups (optional, max 3).** Suggest follow-up directions only when they'd meaningfully extend the work, or an important adjacent topic is clearly implied. When in doubt, suggest none.
+
+## Language and region
+
+- Respond in the language the user writes in (Spanish or English). Formal research documents use that same language unless told otherwise.
+- Region/market scope is never silently assumed. If not stated, it is covered by the Scope check question in step 2 — not defaulted.
+
+## Format and style
+
+- Deliver formal research in structured Markdown: clear headings, logical sections, concise paragraphs.
+- Always flag temporal relevance: distinguish recent findings (last 12–24 months) from structural/historical context.
+
+## Social listening
+
+Public forums, social media (LinkedIn, X, Reddit, Facebook groups, specialized communities), and review platforms may supplement primary research to capture sentiment, emerging trends, and qualitative signals.
+
+- Never cite social listening findings as factual or statistical evidence — label them explicitly as qualitative/anecdotal.
+- Use them to complement, never substitute, primary or institutional sources.
+- Prefer professional communities (LinkedIn, specialized forums) over general social platforms for industry/tech topics.

--- a/global-claude/skills/pl-explanation-style/SKILL.md
+++ b/global-claude/skills/pl-explanation-style/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: pl-explanation-style
+description: When explaining a programming language's syntax, semantics, type system, or runtime execution model — not a specific program written in it — use formal grammar and VM/hardware execution vocabulary, not plain-language description. Covers grammar/semantics (CFGs, parsing, AST, typing judgments, inference rules, soundness) and execution model (registers, calling conventions, stack/heap, VM dispatch loops, memory model, concurrency), loaded by relevance rather than either/or. Trigger for why code is a syntax or type error, how type inference/checking works, why code behaves oddly at runtime (races, aliasing, undefined behavior), how an interpreter/VM executes instructions, what a memory model guarantees, or any "why does this language do X" question — even without the words "grammar," "semantics," or "type system." Distinct from softwarecs-explanation-style, which covers a program/tool/service as a system (pipeline, I/O), not a language's own rules.
+---
+
+## Overview
+
+When a question is about what a programming language *permits, means, or
+does at runtime* — not about a specific tool that happens to be written
+in it — assume computer science literacy and describe it using the
+formal vocabulary in the matching reference file(s) below, rather than
+plain-language description ("that's just not allowed" / "it crashes
+because of memory stuff").
+
+## When to use this skill
+
+Use this framing when explaining:
+- Why a piece of code is or isn't valid syntax.
+- Why code does or doesn't type-check, or how type inference reaches a
+  particular type.
+- What a language construct actually means (assignment, pass-by-value
+  vs. pass-by-reference, closures, generics/monomorphization).
+- Why code behaves a certain way at runtime — a data race, aliasing,
+  undefined behavior, unexpected performance.
+- How an interpreter, VM, or the underlying hardware actually executes
+  a construct.
+
+**Not this skill:** "how does `gcc`/`rustc`/`node` work as a program" is
+a question about a *tool*, not the language it implements — that's
+`softwarecs-explanation-style` (`references/local.md`, since a compiler
+binary is a local pipeline). Some questions need both: "why did
+upgrading the compiler change this program's behavior" is a pipeline
+question (that skill) *and* a language-semantics question (this one) —
+describe the compiler as a program in the former's vocabulary, the
+specific rule that changed in this skill's, and make the handoff
+explicit rather than picking one.
+
+## Step 0: identify which concepts are load-bearing, then read the matching reference(s)
+
+Unlike `softwarecs-explanation-style`'s local/networked split, the two
+reference files below are not mutually exclusive branches selected by
+classifying the system — they're two lenses that are each independently
+relevant depending on what the question is actually asking. Load
+whichever the question needs; don't force a single-file answer if the
+question spans both.
+
+- **`references/grammar.md`** — for questions about the validity,
+  structure, or static meaning of code as written: syntax, parsing,
+  ASTs, type systems, type inference, soundness. Read this when the
+  question is "is this valid," "why won't this type-check," "what does
+  this construct mean before it runs."
+- **`references/execution-model.md`** — for questions about what
+  happens when code actually runs: registers, calling conventions,
+  stack/heap layout, a VM's dispatch loop, memory model, concurrency
+  semantics. Read this when the question is "why does this
+  crash/race/behave differently," "how is this executed," "what does
+  the runtime guarantee."
+
+Many substantive questions need both at once — e.g. "why does
+monomorphizing this generic change its calling convention" is
+inseparably a type-system question (`grammar.md`) and a
+calling-convention question (`execution-model.md`). Read both and
+connect them explicitly rather than picking one arbitrarily because it
+seemed like the primary one.
+
+## Notes
+
+- Don't force this vocabulary onto explanations that aren't about a
+  language's own rules — a question about a specific library's API
+  design, or a non-CS topic, should use plain framing or
+  `softwarecs-explanation-style` as appropriate, not this skill's
+  grammar/execution vocabulary grafted on.
+- If a compiler or interpreter's *implementation* is itself the
+  subject — its pipeline, its binary, its file I/O — that's
+  `softwarecs-explanation-style`; this skill still supplies the
+  grammar/execution vocabulary for describing what that program's
+  parser or codegen phase is implementing, so the two are meant to be
+  read together for questions like "why does this parser reject valid
+  syntax."
+- Pairs with the "Technical Explanation Structure" skill the same way
+  `softwarecs-explanation-style` does, for the overall shape of the
+  explanation (why / how / contract) — this skill supplies vocabulary
+  for the "how," not the structure around it.
+- If the person's own framing suggests they aren't asking as an
+  engineer, this skill shouldn't override that context — use judgment.
+
+## Changelog
+
+- **1.0** — Initial version: grammar/semantics and execution-model
+  references, loaded by relevance rather than exclusive branch.

--- a/global-claude/skills/pl-explanation-style/references/execution-model.md
+++ b/global-claude/skills/pl-explanation-style/references/execution-model.md
@@ -1,0 +1,78 @@
+# Execution model framing
+
+Loaded when the question is about what actually happens when code runs
+— below the level of "the language lets you do this" and down to how a
+CPU or VM carries it out. The grammar/type system says what's allowed;
+this file says what it costs and how it's physically realized.
+
+## The template
+
+> At runtime, `<construct>` is realized as `<representation>` — held in
+> `<register / stack slot / heap location>` per `<calling
+> convention/ABI>` — and executed via `<dispatch mechanism>`. Concurrent
+> access to it is governed by `<memory model guarantee>`.
+
+## The concepts, and why each is distinct
+
+**1. Representation & storage** — where a value actually lives:
+a register, a stack frame slot, or the heap, and whether the language
+gives you *value* semantics (copies) or *reference* semantics (aliases
+to the same storage) for that construct. This is the direct runtime
+counterpart of the grammar file's static types — a type says what shape
+a value has; storage says where and how many copies of it exist.
+
+**2. Calling convention / ABI** — how arguments and return values cross
+a function-call boundary: which are passed in registers vs. pushed on
+the stack, which registers the callee must preserve (callee-saved) vs.
+is free to clobber (caller-saved), and how the return address and
+previous frame pointer are recorded so the stack can unwind correctly.
+This is the mechanical layer beneath "the function receives its
+arguments" — different calling conventions (cdecl, System V AMD64,
+a language's own VM-internal convention) make different tradeoffs here,
+and generic/polymorphic calls often need this made explicit (e.g. why
+monomorphization changes what convention applies per instantiation).
+
+**3. Dispatch mechanism** — how the next instruction gets selected and
+run. For compiled/native code this is hardware fetch-decode-execute
+directly. For a VM'd or interpreted language it's a bytecode dispatch
+loop — a switch over opcodes, threaded dispatch, or a JIT that
+compiles hot paths to native code partway through execution. Naming
+which one applies is what turns "the interpreter runs your code" into
+an actual explanation of the performance or behavior in question.
+
+**4. Memory model & concurrency semantics** — what a concurrent read is
+guaranteed to observe about a concurrent write: sequential consistency,
+a happens-before relation, or (for a data race) no guarantee at all,
+which in some languages is explicitly classified as undefined behavior
+rather than merely "unpredictable." This has no equivalent in the
+grammar file's static world — it's specifically about what multiple
+threads of execution can observe about shared storage, and it's the
+concept that turns "this is a race condition" into a precise claim
+about which guarantee is violated.
+
+## Example
+
+Instead of: "Recursion uses up memory with each call."
+
+Prefer: "Each call pushes a new stack frame holding the callee's local
+variables, its return address, and — per the calling convention — the
+arguments that didn't fit in registers. Unwinding on return pops that
+frame. Without tail-call optimization, a frame stays live for the
+entire duration of the call it made, so recursion depth is bounded by
+stack size, not by heap availability."
+
+## Notes
+
+- Pairs with `grammar.md` whenever the explanation needs both what a
+  construct is typed as and how it's realized at runtime — most
+  "why is this generic/polymorphic call slow" or "why does this type
+  change memory layout" questions need both.
+- If the subject is a specific interpreter or VM's *implementation*
+  (its source files, its dispatch loop as a body of code, its build) —
+  rather than the execution semantics it's realizing — that's
+  `softwarecs-explanation-style`'s `local.md`: a VM is itself a program
+  with a path and a pipeline, same as any local process. This file
+  supplies the vocabulary for describing what that dispatch loop is
+  doing, not for describing the program that contains it.
+- Pairs with the "Technical Explanation Structure" skill for the overall
+  shape of the explanation.

--- a/global-claude/skills/pl-explanation-style/references/grammar.md
+++ b/global-claude/skills/pl-explanation-style/references/grammar.md
@@ -1,0 +1,95 @@
+# Grammar & semantics framing
+
+Loaded when the question is about the validity, structure, or static
+meaning of code as written — before it ever runs. Covers syntax through
+type systems as one continuum: both are formal systems of rules that
+decide, independent of any implementation, what's permitted and what it
+means.
+
+## The template
+
+> A construct is syntactically valid if it can be derived from
+> `<grammar rule>`. Where types apply, it's well-typed if
+> `<typing judgment>` holds under `<context/environment>` — derived via
+> `<inference rule(s)>`. Its static meaning is `<what the type/shape
+> guarantees, independent of execution>`.
+
+Not every explanation needs the full chain — a syntax question may stop
+at the grammar rule; a type-inference question usually needs the
+judgment and the rule that derives it.
+
+## The concepts, and why each is distinct
+
+**1. Grammar (syntax)** — the context-free grammar (CFG) rules,
+typically read or written in BNF/EBNF, that define which token
+sequences are well-formed. A grammar has terminals and nonterminals,
+production rules, and can be ambiguous (more than one valid derivation
+for the same input) — which is why parsing *strategy* matters: LL,
+LR/LALR, PEG, and recursive descent resolve ambiguity differently and
+accept different (sometimes overlapping, sometimes distinct) grammar
+classes. "This doesn't parse" is a grammar-rule violation, not a vague
+"syntax error."
+
+**2. Parse tree vs. AST** — a parse tree records every grammar rule
+applied, including rules that exist only to express precedence or
+disambiguate (e.g. an `Expr → Term → Factor` chain for arithmetic). The
+AST discards that scaffolding and keeps only the structure that matters
+semantically. Conflating the two hides why a language's parser and its
+type checker operate on different-shaped trees.
+
+**3. Static (typing) semantics** — the typing judgment, conventionally
+written `Γ ⊢ e : τ` ("under context Γ, expression e has type τ"), is
+derived via inference rules the same way a parse is derived via grammar
+rules — same formal move, different rule set. Type *inference*
+(e.g. Hindley-Milner via unification) is the algorithm that reconstructs
+missing type annotations by solving those judgments rather than
+requiring them written out. Distinguish this from parsing explicitly:
+a program can parse successfully and still fail typing — two separate
+checks, two separate failure modes, exactly as AuthN and AuthZ are
+separate failure modes in the networked framing.
+
+**4. Soundness & decidability** — soundness is the guarantee that a
+well-typed program can't reach a stuck state at runtime (informally,
+"well-typed programs don't get stuck," Milner's slogan) — it's what
+makes the static check worth trusting instead of just running the code
+to find out. Decidability is whether the type-checking algorithm is
+even guaranteed to terminate with an answer — relevant when explaining
+why some type systems need annotations the language "shouldn't" require
+in principle (full inference for the feature is undecidable, so the
+language falls back to requiring a hint).
+
+**5. Dynamic semantics as a definition, not a story** — operational
+semantics (small-step or big-step reduction rules) defines what a
+construct *means* as a formal rewrite process, independent of any
+particular interpreter's implementation. This is worth distinguishing
+from `execution-model.md`'s vocabulary: operational semantics is "what
+transformation this expression is defined to undergo," while the
+execution model is "what a specific machine or VM actually does to
+carry that transformation out." The former is one definition; the
+latter can vary by implementation while still honoring it.
+
+## Example
+
+Instead of: "You can't add a string and a number because that's not
+allowed."
+
+Prefer: "The `+` operator's typing rule requires both operands to unify
+to the same type variable. `string` and `number` don't unify under this
+language's rules, so unification fails during type inference — the
+expression is rejected before it's ever evaluated. This is a static
+error, not a runtime one: the program never reaches a state where `+`
+would have to decide what to do with mismatched operands."
+
+## Notes
+
+- Pairs with `execution-model.md` whenever the "how" also needs runtime
+  behavior — e.g. explaining monomorphization needs both this file's
+  type-system vocabulary and the execution file's calling-convention
+  vocabulary.
+- If the subject is a specific parser or type checker's *implementation*
+  (a binary that reads source and emits an AST) rather than the
+  grammar/type rules themselves, that's `softwarecs-explanation-style`'s
+  `local.md` — a parser generator is a program with a path, an input
+  format, and an output data structure, same as any local pipeline.
+- Pairs with the "Technical Explanation Structure" skill for the overall
+  shape of the explanation.

--- a/global-claude/skills/softwarecs-explanation-style/SKILL.md
+++ b/global-claude/skills/softwarecs-explanation-style/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: softwarecs-explanation-style
+description: When explaining software, code, or technical systems, use CS-native framing — binaries/paths, data structures, algorithms, file formats, parsing — instead of plain-language description. Covers both local-machine systems (compilers, parsers, local pipelines, on-disk formats) and networked/distributed systems (API calls, client-server auth, remote fetches). Always check whether the system being explained crosses a process or machine boundary — fetches from, or authenticates against, anything outside local disk/memory — and load the matching reference file, even partially for hybrid systems.
+---
+
+## Overview
+
+When the explanation is about software specifically — a program, a
+service, a library, a file format, a pipeline — assume computer science
+literacy rather than explaining down to a lay audience. Describe the
+system the way an engineer would describe it to another engineer, using
+the vocabulary in the matching reference file below.
+
+## When to use this skill
+
+Use this framing when explaining:
+- How a program, tool, or service works internally.
+- How data moves through a pipeline or system.
+- How a file format, protocol, or on-disk structure is organized.
+- How a client and server, or two services, communicate.
+
+Pairs naturally with the "Technical Explanation Structure" skill — that
+skill supplies the shape (why / how / contract), this skill supplies the
+vocabulary for the "how" section when the topic is software.
+
+## Step 0: classify the system, then load the matching reference
+
+This skill's only job is routing. Before writing anything, decide
+whether the system crosses a boundary, then read the corresponding file
+— the vocabulary lives there, not here:
+
+- **Purely local** — everything the system needs is already on disk or
+  in memory on the machine running it (a compiler, a parser, an
+  in-process pipeline). Read `references/local.md`.
+- **Purely networked** — the system's whole job is to talk to something
+  else over a wire (an API client, a webhook handler). Read
+  `references/networked.md`.
+- **Hybrid** — a local process that, at some point, fetches from or
+  authenticates against something external (a CLI tool that calls out
+  to a remote API; a build step that pulls a dependency; a local git
+  binary pushing over HTTPS with a credential helper). This is common —
+  don't assume "explaining a local tool" rules out the network. Read
+  **both** files: describe the local phase with `references/local.md`,
+  the remote phase with `references/networked.md`, and make the
+  **handoff between them** explicit — that boundary crossing is usually
+  the most important part of the explanation, not an afterthought.
+
+If unsure which bucket a system falls in, check: does it ever resolve
+an address, open a socket, or present a credential to something it
+doesn't share a filesystem with? If yes, it's hybrid or networked, not
+purely local.
+
+## Notes
+
+- Don't force this vocabulary onto explanations that aren't about
+  software/CS systems — a question about, say, tax law or a business
+  process should use the general structure skill's framing without CS
+  jargon grafted on.
+- If the person's own framing suggests they aren't asking as an engineer
+  (e.g., a stakeholder-level question), this skill shouldn't override
+  that context — use judgment.
+- Don't load `references/networked.md` for systems that are purely
+  local — it adds vocabulary (transport, auth, failure semantics) that's
+  irrelevant noise for a compiler or a local parser, and vice versa.
+- Don't route questions about a *language's own rules* here — "why is
+  this a syntax error," "why won't this type-check," "why is this a
+  data race possible" are about the language, not about a system with a
+  process boundary, even though they're clearly CS/software topics. Use
+  the "PL Explanation Style" skill instead. The boundary case: "how does
+  `gcc` work" is this skill (`local.md` — it's a binary at a path with a
+  pipeline); "what does the C grammar or type system allow" is PL
+  Explanation Style — same binary, two different questions about it.
+
+## Changelog
+
+- **1.3** — Added a Notes bullet distinguishing this skill (systems,
+  tools, pipelines with a process boundary) from the new "PL
+  Explanation Style" skill (a language's own syntax/type/execution
+  rules), with the `gcc`-as-program-vs-`gcc`-as-C-implementation
+  boundary case as the disambiguator.
+- **1.2** — SKILL.md reduced to pure routing logic. Local framing moved
+  out of the body into `references/local.md`, mirroring `networked.md`.
+- **1.1** — Split into router + `references/networked.md`. Added Step 0
+  boundary classification and the hybrid case. Local framing content
+  unchanged from 1.0.
+- **1.0** — Initial version: local-machine framing only.

--- a/global-claude/skills/softwarecs-explanation-style/references/local.md
+++ b/global-claude/skills/softwarecs-explanation-style/references/local.md
@@ -1,0 +1,47 @@
+# Local-machine system framing
+
+Loaded when a system doesn't cross a process or machine boundary —
+everything it needs is already on disk or in memory on the machine
+running it (a compiler, a parser, an in-process pipeline). If any part
+of the system fetches from or authenticates against something external,
+use `references/networked.md` for that part instead (see the router's
+Step 0 for the hybrid case).
+
+## The template
+
+> `<program>` is a `<binary/process>` living at `<path>`. It takes
+> `<input>` as `<file format>`, parses it into `<data structure>`,
+> processes it using `<algorithm/technique>`, produces
+> `<output data structure>`, and serializes that to `<output file(s)>`
+> in `<format>`.
+
+Concretely, favor:
+- **Data structures** over vague nouns — say "a hash map keyed by user
+  ID" rather than "a lookup."
+- **Algorithms** by name where one exists — say "topological sort,"
+  "binary search," "LRU eviction" rather than "figures out the order" or
+  "decides what to keep."
+- **File formats and parsing** as the seam between components — describe
+  the on-disk or on-wire representation, and treat parsing/serialization
+  as the explicit boundary between "how it's processed" and "how it's
+  exposed."
+- **Paths and binaries** as concrete anchors — real or representative
+  file paths and process names, not abstractions like "the system."
+
+## Example
+
+Instead of: "The compiler reads your code and turns it into a program the
+computer can run."
+
+Prefer: "`gcc` is a binary that takes your `.c` source files as input,
+parses them into an abstract syntax tree, runs that AST through several
+optimization passes, generates machine code, and hands it to the linker,
+which produces an ELF binary as output."
+
+## Notes
+
+- Pairs with `references/networked.md` whenever a system is hybrid —
+  describe the local phase here, the remote phase there, and call out
+  the handoff between them.
+- Pairs with the "Technical Explanation Structure" skill the same way
+  the router does, for the overall shape of the explanation.

--- a/global-claude/skills/softwarecs-explanation-style/references/networked.md
+++ b/global-claude/skills/softwarecs-explanation-style/references/networked.md
@@ -1,0 +1,104 @@
+# Networked / distributed system framing
+
+Loaded when a system (or part of one — see the hybrid case in the
+router) fetches from, or authenticates against, something outside local
+disk/memory. The local template's assumptions break down here in five
+specific ways; each gets its own vocabulary below instead of being
+folded into "it makes a request."
+
+## The template
+
+> `<client>` resolves `<endpoint>` via `<addressing mechanism>` and
+> sends `<request representation>` over `<transport/protocol>`,
+> presenting `<credential>` to authenticate (`<AuthN mechanism>`) and be
+> authorized (`<AuthZ policy>`), with the channel protected by
+> `<trust mechanism>`. The `<server/process>` parses the request, does
+> `<processing>`, and returns `<response representation>` serialized as
+> `<wire format>`. On failure: `<timeout/retry/idempotency behavior>`.
+
+You won't fill in every slot every time — see "How much to include"
+below. Treat the five concepts as the checklist to run against, not a
+mandatory template to complete in full.
+
+## The five concepts, and why each is distinct
+
+**1. Transport and addressing** — how the target is located and how
+bytes actually move. Not "it connects to the server," but: resolved via
+DNS or a service registry, spoken over TCP/HTTP/2/QUIC/gRPC. This is
+the direct extension of "fetching" — the local template has no
+addressing step because the input is already at a known path; a network
+call has to find its target before it can read anything.
+
+**2. Authentication vs. authorization** — two different questions,
+routinely collapsed into one. AuthN answers *who is calling* (a bearer
+token, a client cert, a signed request). AuthZ answers *what that caller
+is allowed to do*, evaluated separately (a scope, a role, an ACL entry).
+A request can authenticate successfully and still be denied — if the
+explanation doesn't distinguish the two, that failure mode becomes
+inexplicable.
+
+**3. Trust boundary in transit** — orthogonal to both of the above. TLS
+(or mTLS) answers whether the channel itself can be read or altered by
+something in the middle, independent of who the endpoints are or what
+they're allowed to do. Local reads have no equivalent concept — the
+data never leaves a boundary you already trust.
+
+**4. Failure semantics** — the biggest gap versus local framing. A local
+`read()` succeeds or errors cleanly and atomically. A network call can
+time out with the request already applied server-side, fail on the
+response leg after the request succeeded, or succeed later than the
+caller gave up waiting. This is why retries, timeouts, and — critically
+— **idempotency** (can this safely be sent twice?) belong in the
+explanation whenever the system does anything non-trivial on failure.
+Don't describe a network call as if it has the same success/fail
+binary as a file read.
+
+**5. Wire format versioning** — on disk, the producer and consumer are
+usually the same build. Over a network, client and server deploy
+independently, so the serialized format has to tolerate one side
+changing before the other does (additive fields, version headers,
+schema negotiation). Worth naming explicitly when the explanation
+involves an API contract, less so for a one-off internal call.
+
+## Secondary concepts (mention only if relevant)
+
+- **Statefulness across calls** — HTTP is stateless by design; anything
+  that behaves statefully (a session cookie, a bearer token with a
+  lifetime, a WebSocket) is doing so via an explicit mechanism layered
+  on top, not for free.
+- **Caching / staleness** — is data fetched fresh every call, or served
+  from a cache with an invalidation policy? Only worth raising if the
+  explanation's correctness depends on freshness.
+
+## How much to include
+
+Not every networked explanation needs all five. A simple internal call
+within an already-trusted boundary may not need AuthZ or transport
+security spelled out. Judge by what's load-bearing for the specific
+question being asked — the same discipline the local template applies
+to data structures and algorithms: name the concept precisely when it
+matters, don't pad the explanation with irrelevant boilerplate.
+
+## Example
+
+Instead of: "Git talks to GitHub to push your code, and it needs your
+login to do that."
+
+Prefer: "`git push` resolves the remote's hostname via DNS, opens an
+HTTPS connection, and hands the request to a credential helper — on
+Windows, `git-credential-manager.exe` — which supplies a personal
+access token as a bearer credential. GitHub authenticates the token
+(AuthN) and separately checks it's scoped for `repo` write access on
+that specific repository (AuthZ). The connection itself is TLS-protected
+independent of the token check. If the push is rejected — expired
+token, wrong scope, network drop mid-request — git surfaces a non-zero
+exit and the specific HTTP status rather than silently retrying,
+because a push is not always safe to blindly resend."
+
+## Notes
+
+- Pairs with the router `SKILL.md`'s local framing whenever a system is
+  hybrid — describe the local phase in that vocabulary, the networked
+  phase in this one, and call out the handoff between them.
+- Pairs with the "Technical Explanation Structure" skill the same way
+  the router does, for the overall shape of the explanation.

--- a/global-claude/skills/swe-prior-art-research/SKILL.md
+++ b/global-claude/skills/swe-prior-art-research/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: swe-prior-art-research
+description: "Research prior art and evaluate technical feasibility for a software engineering problem or idea — has this been solved, built, or attempted before, and is it viable given real constraints. Trigger on requests to check whether an approach/idea/problem has precedent, existing solutions, or prior attempts, or whether something is technically feasible/worth building. Mutually exclusive with industry-research-analyst — resolve by what the answer needs to conclude, not by keyword: a personal build-vs-buy decision (even phrased as \"has anyone built X\") routes here, since surveying what exists is only an input to that decision; a market/competitive landscape report routes to industry-research-analyst instead. Also distinct from technical-explanation-structure (explaining an already-identified system)."
+---
+
+# Software Engineering Prior-Art & Feasibility Research
+
+Act as a research engineer whose job is to prevent reinvented wheels and
+premature builds. The output isn't a landscape — it's an answer to
+"has this been done, how, and should I do it too."
+
+## Workflow
+
+1. **Frame the problem precisely.** Restate the problem/idea in specific
+   technical terms: inputs, constraints, what "solved" would mean. If it
+   maps onto a known CS problem class (e.g. "this is a variant of
+   consistent hashing," "this is bin packing under X constraint"), name
+   it before searching — misclassifying a known problem as novel wastes
+   the research pass.
+
+2. **Novelty classification (routing).** Decide which of three buckets
+   this falls in, since it determines search strategy:
+   - **Well-trodden** — established literature/solutions exist. Go
+     straight to canonical approaches and survey-level sources.
+   - **Known class, novel combination** — the general problem is known
+     but the specific constraint mix may not be. Search the general
+     class, then check adjacent/analogous problems for the specific
+     combination.
+   - **Plausibly novel** — no obvious precedent. Search adjacent
+     problems and decompose into sub-problems that likely *do* have
+     precedent individually.
+
+3. **Scope/constraints check.** If unclear, ask ONE consolidated
+   question covering: hard constraints (language/stack, scale, latency,
+   existing infra), what "feasible" means in this context (prototype vs.
+   production), and what's already been tried. Skip if already clear
+   from context.
+
+   For **well-trodden** problems (step 2), don't frame this as "is it
+   feasible" — step 2 already answered that (yes, established solutions
+   exist). Frame it as "which constraint determines which known approach
+   fits" instead. The open question at that point is applicability, not
+   existence.
+
+4. **Research brief.** Before the full research, state: the source
+   types you'll draw from, the angle (canonical-solution survey vs.
+   analogous decomposition, per step 2), and what's intentionally out of
+   scope.
+
+5. **Structured findings.** Evidence-rich, source-cited. For each prior
+   attempt found: who did it, how, what tradeoffs they accepted, and any
+   maturity/adoption signal. Distinguish established practice from
+   one-off/experimental work. Explicitly surface failure reports —
+   "attempted X, abandoned because Y" is often the most valuable finding.
+
+6. **Feasibility verdict.** Unlike a landscape report, this closes with
+   an explicit assessment: technical feasibility given the stated
+   constraints, what's directly reusable vs. needs adaptation, the
+   single biggest risk/unknown, and — if nothing relevant turned up —
+   say so plainly. Absence of prior art is itself a data point (higher
+   risk, or a genuine opportunity), not just a dead end.
+
+7. **Follow-ups (optional, max 3).** Only if they'd meaningfully extend
+   the work. When in doubt, suggest none.
+
+## Source hierarchy
+
+- **Primary/technical**: papers (arXiv, ACM/IEEE), RFCs/specs, standards
+  docs, OSS source and issue trackers, engineering blogs from teams that
+  shipped the thing, postmortems.
+- **Community signal (qualitative only)**: HN, Stack Overflow, Reddit,
+  mailing lists. Treat as war-stories evidence for failure modes and
+  real-world friction — never as authoritative technical fact. Same
+  discipline as "social listening" in the market-research skill, but
+  calibrated for engineering credibility, not sentiment.
+- **Adoption-signal weighting (within any tier)**: package registries
+  and technical blogs are increasingly padded with abandoned,
+  copy-cat, or AI-generated filler content — a plausible-sounding
+  source with no adoption evidence is noise, not a finding. Weight by
+  stars/downloads/commit recency and known production users before
+  treating something as a real data point. Prose that reads like
+  marketing copy (unverifiable claims of expert review or endorsement,
+  generic superlatives with no specifics) is itself a signal to
+  discount the source, not cite it.
+
+## Format and style
+
+- Structured Markdown, source-cited, concise paragraphs.
+- Flag temporal relevance — a 2015 approach to a since-solved problem
+  (e.g. pre-io_uring Linux I/O patterns) needs that context stated, not
+  presented as current best practice.
+- State confidence explicitly where evidence is thin — don't let a
+  single blog post read as consensus.
+
+## Notes
+
+- Pairs with `softwarecs-explanation-style` / `pl-explanation-style` when
+  a found solution's internals need explaining — this skill finds and
+  judges prior art, those supply the vocabulary for describing how it
+  works.
+- Pairs with `technical-explanation-structure` for the shape of any
+  "how does the found solution work" subsection.
+- Open question for later: if the novelty classification (step 2) ends
+  up needing genuinely different content per bucket rather than just a
+  different search angle, that's the signal to split into router +
+  references — not before.
+- **Mutual exclusion with `industry-research-analyst`**: don't
+  disambiguate by keyword ("has anyone done X" vs. "worth building") —
+  compound buy-vs-build queries contain both phrases at once and that
+  test failed under the old wording. Disambiguate by what the answer
+  needs to conclude: if the requester is deciding their own build/adopt
+  action, this skill applies even though it requires surveying what
+  exists — the survey is an input, not the deliverable. If the
+  deliverable itself is a landscape/competitive report, that's
+  `industry-research-analyst`.
+
+## Changelog
+
+- **0.3 (draft)** — Re-tested the mutual-exclusion boundary with a
+  compound buy-vs-build query ("has anyone built X... worth building
+  our own?"). Old keyword-based clause failed — both halves of the
+  sentence matched a different skill's trigger phrase. Replaced with a
+  tie-breaker: resolve on what the answer needs to conclude (personal
+  build/adopt decision vs. landscape report), not on which phrase
+  appears.
+- **0.2 (draft)** — Tested against 4 inline cases (2 trigger, 1
+  boundary, 1 edge case). Fixes: adoption-signal weighting added to
+  source hierarchy (low-quality/AI-generated filler was crowding
+  legitimate results); mutual-exclusion clause added against
+  `industry-research-analyst`, keyed on intent (build vs. compare)
+  rather than topic overlap; step 3's constraint question reframed for
+  well-trodden cases, where existential feasibility is already settled
+  by step 2 and the open question is applicability.
+- **0.1 (draft)** — Initial sketch, not yet validated or packaged.

--- a/global-claude/skills/technical-explanation-structure/SKILL.md
+++ b/global-claude/skills/technical-explanation-structure/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: technical-explanation-structure
+description: Structures "how does X work" explanations into historical context/problem, the process behind it, and the input/output contract with the user. For in-depth explanations, not quick facts.
+---
+
+## Overview
+
+When explaining how something works — a system, a process, a tool, a
+solution — don't describe the mechanism in isolation. Build the explanation
+in three connected layers so the reader understands not just *what* happens,
+but *why* it happens that way, and *what they can rely on* without needing
+to track the internals.
+
+## When to use this skill
+
+Use this structure when:
+- The user asks "how does X work," "why is X built this way," or "explain
+  X to me" for a system, process, tool, or solution.
+- The explanation is substantive enough to benefit from structure (more
+  than a couple of sentences).
+
+Don't use this structure for:
+- Quick factual lookups ("what year was X released").
+- Simple yes/no or definitional answers.
+- When the user explicitly asks for a short answer, a specific format, or
+  only one of the three parts below.
+
+## The three-part structure
+
+### 1. Historical context & problem statement — the "why"
+
+State the problem that existed before the solution, and briefly how it came
+to be recognized as a problem. This is what gives the rest of the
+explanation a reason to exist rather than reading as an arbitrary design.
+
+### 2. Process behind the solution — the "how," tied back to the "why"
+
+Explain the actual mechanism, but keep drawing the connection back to
+Part 1: each design choice in the process should visibly trace back to a
+constraint or problem named above. Avoid describing the mechanism as a
+free-standing sequence of steps disconnected from why those steps exist.
+
+### 3. The interface contract — presentation vs. processing
+
+Close by stating the boundary the user actually operates at: what they hand
+in (A), what they get back (B), and make explicit that the internals from
+Part 2 are exactly what they don't need to track to use the solution
+correctly. Frame this as a contract: "You provide A, you receive B, and you
+don't need to reason about how A becomes B to rely on the result." This is
+the payoff — it tells the reader what they can safely forget.
+
+## Notes
+
+- Keep proportion sensible: for a simple topic, each part can be one or two
+  sentences. Don't pad a simple mechanism into three bloated sections.
+- When the topic is software/CS specifically, pair this structure with
+  CS-native framing in Part 2 rather than plain-language description —
+  but which companion skill supplies that framing depends on what's
+  being explained, not just that it's "software":
+  - Explaining a *program, tool, or service* — something with a process
+    boundary, a pipeline, an I/O contract ("how does `gcc` work," "how
+    does this API authenticate a request") — see "Software/CS
+    Explanation Style."
+  - Explaining a *language's own rules* — syntax validity, type
+    checking, why code behaves a certain way at runtime ("why is this a
+    type error," "why is this a race condition") — see "PL Explanation
+    Style."
+  - Some questions need both (e.g. "why did upgrading the compiler
+    change this program's behavior" is a pipeline question and a
+    language-semantics question at once) — pull in both skills and make
+    the handoff between them explicit, the same way either skill does
+    internally when a system spans more than one framing.
+- If the user only wants the mechanism itself and not the framing, they'll
+  typically say so directly ("just the process," "skip the background") —
+  respect that and drop the other two parts rather than forcing the full
+  structure.

--- a/tests/test_config.bats
+++ b/tests/test_config.bats
@@ -4,7 +4,10 @@
 # Covers config.sh's own correctness and the four-layer precedence chain
 # (hardcoded defaults < config.sh < config.local.sh < env var), not
 # container runtime behavior — no engine daemon is required for any test
-# in this file, so setup() does not gate on engine_available.
+# in this file, so setup() does not gate on engine_available. Every test
+# here therefore also carries the `hostonly` tag, which is the axis CI
+# filters on — `fast` is about duration and does not imply an engine-free
+# test (see BUILDING.md, "Tag axes").
 #
 # None of these tests touch a real config.local.sh: an operator's own
 # gitignored file must never be read, written, or deleted by the test
@@ -36,7 +39,7 @@ _reg_fixture_dir() {
 }
 
 @test "C-1: env var overrides config.sh's value for the same variable" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     run env ENGINE=docker bash -c '
         set -euo pipefail
         cd "'"${SANDBOX_DIR}"'"
@@ -51,7 +54,7 @@ _reg_fixture_dir() {
 }
 
 @test "C-2: config.sh overrides the hardcoded layer-1 default when no env var is set" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     run bash -c '
         set -euo pipefail
         cd "'"${SANDBOX_DIR}"'"
@@ -64,7 +67,7 @@ _reg_fixture_dir() {
 }
 
 @test "C-3: config.sh's PROFILES matches the profile directories actually present" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     run bash -c '
         set -euo pipefail
         cd "'"${SANDBOX_DIR}"'"
@@ -80,7 +83,7 @@ _reg_fixture_dir() {
 }
 
 @test "C-4: config.sh's PROFILE_BASE only references profiles PROFILES actually declares" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     # Regression guard: a typo'd or stale base-dependency entry (e.g.
     # pointing at a renamed/removed profile) would silently no-op the
     # build.sh dependency lookup rather than fail loudly.
@@ -108,7 +111,7 @@ _reg_fixture_dir() {
 }
 
 @test "C-5: build.sh rejects a target not present in config.sh's PROFILES, without touching an engine" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     # No engine daemon required: dispatch to the "Unknown target" branch
     # happens before build.sh ever shells out to $ENGINE.
     run bash "${SANDBOX_DIR}/build.sh" definitely-not-a-real-profile
@@ -117,7 +120,7 @@ _reg_fixture_dir() {
 }
 
 @test "C-6: build.sh and start.sh both source config.sh, not a re-copied literal list" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     # Structural guard for the drift problem this design exists to fix:
     # both scripts must read PROFILES from the same sourced file rather
     # than hardcoding their own copies that could silently diverge again.
@@ -128,7 +131,7 @@ _reg_fixture_dir() {
 # C-7 onward: named project registry (docs/designs/named-project-registry.md)
 
 @test "C-7: @name resolves to the registered path and its registry profile" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     mkdir -p "${REG_TMPDIR}/mylib"
     cat > "${REG_TMPDIR}/config.sh" <<EOF
@@ -143,7 +146,7 @@ EOF
 }
 
 @test "C-8: an explicit second argument overrides the registry's profile" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     mkdir -p "${REG_TMPDIR}/mylib"
     cat > "${REG_TMPDIR}/config.sh" <<EOF
@@ -157,7 +160,7 @@ EOF
 }
 
 @test "C-9: an unknown @name exits non-zero and never reaches the engine" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     cat > "${REG_TMPDIR}/config.sh" <<EOF
 PROJECT_PATH[mylib]="${REG_TMPDIR}/mylib"
@@ -172,7 +175,7 @@ EOF
 }
 
 @test "C-10: a name with a path but no profile is reported, not a 'set -u' crash" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     # Regression guard for the two-array sync problem the design doc calls
     # out: PROJECT_PATH and PROJECT_PROFILE can drift apart, and the ':-'
     # guards at the read site must turn that into the intended error
@@ -191,7 +194,7 @@ EOF
 }
 
 @test "C-11: a bare name matching a registry entry is still treated as a path" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     # The sigil boundary: from a directory containing a "mylib" subdirectory,
     # "./start.sh mylib" (no @, no second argument) must resolve as a plain
     # relative path and fall through to the base-profile default — not
@@ -212,7 +215,7 @@ EOF
 }
 
 @test "C-12: a name added only in config.local.sh resolves correctly" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     mkdir -p "${REG_TMPDIR}/localonly"
     : > "${REG_TMPDIR}/config.sh"   # no committed entries
@@ -229,7 +232,7 @@ EOF
 }
 
 @test "C-13: config.local.sh redefining a committed name is reverted and warned, not honored" {
-    # bats test_tags=fast
+    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     mkdir -p "${REG_TMPDIR}/committed-real" "${REG_TMPDIR}/attempted-override"
     cat > "${REG_TMPDIR}/config.sh" <<EOF

--- a/tests/test_docs_integrity.bats
+++ b/tests/test_docs_integrity.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# test_docs_integrity.bats — Group: Documentation Integrity
+#
+# Moves four doc-discipline rules from "prose someone is supposed to follow"
+# to "a check that fails the build" — the enforcement-ladder jump the rest of
+# this repo's conventions have not yet made. Every assertion here was chosen
+# because a real instance of the failure already existed in the tree, or
+# because the failure is invisible until someone clones fresh.
+#
+# No engine daemon is required by any test in this file — it reads tracked
+# files and nothing else — so setup() does not gate on engine_available and
+# lib/engine is not loaded. That is what makes these tests runnable in CI on
+# a stock runner with no container tooling; see the "hostonly" tag below.
+#
+# What this suite deliberately does NOT catch, stated explicitly so nobody
+# mistakes its coverage for more than it is:
+#   - Backtick-quoted repo paths (`docs/AGENTS.md`, `base/entrypoint.sh`).
+#     Six such paths in the tracked docs are illustrative examples rather
+#     than real references, so checking them would produce false positives.
+#     Only markdown links are checked.
+#   - Anchor fragments. A link to a real file with a #heading that no longer
+#     exists still passes D-1.
+#   - Skill references that are not backtick-quoted, including the ones in
+#     a SKILL.md's own frontmatter `description` field.
+#   - Skills named anywhere outside the injected global layer. ADR 002
+#     names `project-feasibility` as a path owner before that skill exists,
+#     which is legitimate — an ADR specifies a target state. A file that is
+#     injected into a live session naming a skill that was never committed
+#     is a breakage. D-2 scans only the latter.
+#   - Absolute or ~-relative paths (the design skill's
+#     ~/.claude/templates/... reference resolves only at container runtime).
+
+SANDBOX_DIR="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+
+# Emits one "<file> -> <link>" line per markdown link that does not resolve.
+# Silence means every link is good. Runs in a subshell so the test's own
+# working directory is left alone.
+_unresolved_markdown_links() {
+    (
+        cd "$SANDBOX_DIR" || exit 1
+        git ls-files '*.md' | while IFS= read -r f; do
+            dir="$(dirname "$f")"
+            grep -oE '\]\([^)]+\)' "$f" 2>/dev/null \
+            | sed -E 's/^\]\(//; s/\)$//' \
+            | while IFS= read -r link; do
+                case "$link" in
+                    http://*|https://*|mailto:*|'#'*) continue ;;
+                esac
+                # Drop any #anchor and any ` "title"` suffix.
+                target="${link%%#*}"
+                target="${target%% *}"
+                [ -z "$target" ] && continue
+                [ -e "${dir}/${target}" ] || echo "${f} -> ${link}"
+            done
+        done
+    )
+}
+
+# Tokens that look like a skill name but are not one. Every entry here is a
+# deliberate exemption from D-2 and shows up as such in a diff — which is
+# the point. An empty list means the rule below is currently unqualified.
+_NOT_SKILL_NAMES=""
+
+# The global layer (global-claude/) is bind-mounted into every session and
+# copied into ~/.claude by base/entrypoint.sh. A skill it names that was
+# never committed exists on the author's machine and nowhere else — the
+# failure this check exists to make impossible.
+#
+# Convention enforced: any backtick-quoted kebab-case token in the global
+# layer is a skill reference. An earlier, narrower version of this rule
+# required the word "skill" adjacent to the name — it matched the single
+# reference that existed at the time and missed every real one that arrived
+# later, because skills cite each other as "Pairs with `other-skill`" and
+# "Mutual exclusion with `other-skill`", not as "`other-skill` skill". A
+# rule that matches only the example it was written against is not a rule.
+#
+# Scope is every *.md in global-claude/, not only the SKILL.md manifests:
+# skills may ship a references/ subdirectory, and a name that dangles there
+# is exactly as broken as one that dangles in the manifest.
+#
+# The broad form is viable because kebab-case in backticks is, empirically,
+# how skills are named and not how anything else in these files is written.
+# When that stops being true, add the token to _NOT_SKILL_NAMES above
+# rather than narrowing the pattern back.
+_unresolved_skill_refs() {
+    (
+        cd "$SANDBOX_DIR" || exit 1
+        # Every Markdown file in the global layer, not just the SKILL.md
+        # manifests: skills may ship a references/ subdirectory, and a
+        # dangling skill name is exactly as broken there as in the manifest.
+        find global-claude -name '*.md' | sort | while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            grep -ohE '`[a-z0-9]+(-[a-z0-9]+)+`' "$f" 2>/dev/null \
+            | tr -d '`' \
+            | sort -u \
+            | while IFS= read -r name; do
+                case " ${_NOT_SKILL_NAMES} " in *" ${name} "*) continue ;; esac
+                [ -f "global-claude/skills/${name}/SKILL.md" ] \
+                    || echo "${f}: names skill '${name}', but global-claude/skills/${name}/SKILL.md is not committed"
+            done
+        done
+    )
+}
+
+# ADRs are never rewritten (docs-as-code-workflow.md §3 Case D), so a
+# missing or invalid Status is not a cosmetic problem — it is the field a
+# reader uses to tell a live decision from a superseded one.
+_malformed_adrs() {
+    (
+        cd "$SANDBOX_DIR" || exit 1
+        for f in docs/adr/*.md; do
+            [ -e "$f" ] || continue
+            grep -qE '^# ADR [0-9]{3} — .' "$f" \
+                || echo "${f}: first heading is not '# ADR NNN — <title>'"
+            status_line="$(awk '/^## Status/{seen=1; next} seen && NF {print; exit}' "$f")"
+            case "$status_line" in
+                Proposed|Accepted|Deprecated|"Supersedes ADR "[0-9][0-9][0-9]) ;;
+                *) echo "${f}: '## Status' is missing or invalid (got: '${status_line}') — expected Proposed, Accepted, Deprecated, or 'Supersedes ADR NNN'" ;;
+            esac
+        done
+    )
+}
+
+_skill_dirs_without_manifest() {
+    (
+        cd "$SANDBOX_DIR" || exit 1
+        for d in global-claude/skills/*/; do
+            [ -d "$d" ] || continue
+            [ -f "${d}SKILL.md" ] || echo "${d}: directory has no SKILL.md"
+        done
+    )
+}
+
+@test "D-1: every relative markdown link in a tracked document resolves" {
+    # bats test_tags=fast, hostonly
+    run _unresolved_markdown_links
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        echo "--- unresolved markdown links ---" >&2
+        echo "$output" >&2
+    fi
+    [ -z "$output" ]
+}
+
+@test "D-2: every skill named in the global layer is committed to global-claude/skills/" {
+    # bats test_tags=fast, hostonly
+    run _unresolved_skill_refs
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        echo "--- skills referenced but not committed ---" >&2
+        echo "$output" >&2
+    fi
+    [ -z "$output" ]
+}
+
+@test "D-3: every ADR has a conforming heading and a valid Status" {
+    # bats test_tags=fast, hostonly
+    run _malformed_adrs
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        echo "--- malformed ADRs ---" >&2
+        echo "$output" >&2
+    fi
+    [ -z "$output" ]
+}
+
+@test "D-4: every directory under global-claude/skills/ contains a SKILL.md" {
+    # bats test_tags=fast, hostonly
+    run _skill_dirs_without_manifest
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        echo "--- skill directories missing a manifest ---" >&2
+        echo "$output" >&2
+    fi
+    [ -z "$output" ]
+}


### PR DESCRIPTION
Closes #37.

Moves four documentation rules from prose nobody can fail to checks that
fail the build, commits the skills the global layer names, and adds the
repository's first CI gate.

**The gate was observed failing before it was trusted.** `D-1` went red on
two dead links in `docs/user_guide.md` — both pointing one directory above
`docs/designs/`, broken since they were written — and green after the fix in
`1d255e1`. `D-2`, `D-3` and `D-4` were each broken deliberately in a scratch
copy and confirmed to fire.

**`D-2` needed widening twice against real content**, which is the argument
for the check existing. It first matched only ``​`name` skill``, the single
phrasing present when it was written, and missed how skills actually cite
each other (`Pairs with `other-skill``). It then missed `references/` files
entirely. A `_NOT_SKILL_NAMES` exemption list makes any future narrowing a
visible diff rather than a quiet pattern edit.

**`hostonly` is a new tag axis, not a rename.** `fast`/`slow` describe
duration; `test_global_layer.bats` G-1 is `fast` and still needs a built
image. CI filters on `hostonly`, which means no engine and no image.

**The workflow guards against passing vacuously.** A mistyped tag makes
`--filter-tags` select zero tests and exit 0. A separate step runs
`bats --count` and fails on zero.

Also commits five skills into `global-claude/skills/`, which is
bind-mounted into every session — they were previously on one machine and
nowhere else. Three of them are explanation-style skills pulled in because
`swe-prior-art-research` cites all three and `D-2` reported each unresolved
until they landed. The injected layer grows from three skills to eight;
that cost is real and was chosen deliberately over rewording the citations.

### Verification

- `bats --filter-tags hostonly tests/` — 17 tests, all pass
- `bats tests/` — full suite green against Podman with all images built
- This PR is the first run of `.github/workflows/ci.yml`; its result is
  itself part of the review

### Not in scope

`shellcheck` in CI, which would go red on `build.sh`/`start.sh` immediately
and make the first CI result about something else; and extending CI to the
slow tier, which would mean building four images per push.
