### PR TITLE
docs: ADRs for agentic SDLC scope and planning artifact contract

### DIFF
--- a/docs/adr/001-agentic-sdlc-scope.md
+++ b/docs/adr/001-agentic-sdlc-scope.md
@@ -1,0 +1,128 @@
+# ADR 001 — Scope and adoption level for agentic SDLC automation
+
+## Status
+
+Accepted
+
+## Context
+
+`../sdlc_reference_guide.md` describes seven phases staffed by project
+managers, business analysts, C-suite sponsors, financial controllers, a
+release manager, a change-management team, and training specialists.
+claude-sandbox has one operator. The phases are portable; the staffing is
+not, and nothing so far has recorded which artifacts in that guide are
+load-bearing here and which are ceremony inherited from an organizational
+context that does not exist.
+
+A research pass in August 2026 into agentic SDLC prior art found the field
+converged on a consistent shape: a single capable agent loop with shell,
+file, and test-runner access; human approval at high-impact actions;
+persistent memory; and context-isolated subagents only where a task is
+genuinely non-trivial. Academic systems that encode the SDLC as multi-agent
+role simulation (MetaGPT's Product Manager / Architect / Engineer / QA,
+ChatDev's virtual company) are widely cited and not widely shipped. Reported
+token cost scales roughly 1× for a chat call, 4× for a tooled single agent,
+15× for a multi-agent system.
+
+That research also produced a four-level maturity ladder. A ladder with no
+declared stopping point is a roadmap, not a decision: every unbuilt level
+becomes an implicit commitment, because silence reads as "not yet."
+
+## Decision
+
+**1. Commit to levels 0 and 1 only.**
+
+| Level | Description | Status |
+|---|---|---|
+| L0 | Manual session; `design` skill Case A–E routing; approval before code and before commit | In force today |
+| L1 | Same control flow, event-triggered — `claude -p` fired by a client signal, phase sequencing still deterministic and ours | Committed target |
+| L2 | Orchestrator delegating to context-isolated subagents | Not committed; gated on the trigger below |
+| L3 | Parallel fan-out across subagents | Out of scope |
+
+L0 and L1 are both *workflows* rather than agents in the sense that matters
+here: the control flow belongs to us, and the model fills in steps.
+
+**2. The L2 trigger, written down so it is checkable.** L2 is reconsidered
+when either is observed and recorded in an issue: a single Planning run
+measurably exhausts the session's usable context, or two sub-steps must read
+large disjoint parts of the repository. Until then L2 stays unbuilt. "It
+would be more elegant" is not the trigger.
+
+**3. Phase mapping.** Which reference-guide artifacts are load-bearing for a
+single operator, and which are not:
+
+| Phase | Load-bearing here | Not applicable here |
+|---|---|---|
+| 1 Planning | Feasibility study, risk inventory, project charter, go/no-go | Budget estimate, C-suite sponsorship, financial-controller sign-off |
+| 2 Requirements | Problem statement and explicit non-goals, folded into the charter and the SDD | SRS as a separately baselined document, RTM, PO/BA roles |
+| 3 Design | `docs/designs/` SDDs and `docs/adr/` ADRs | HLD/LLD split, UI/UX wireframes, DBA and security-engineer sign-off |
+| 4 Development | Source, tests, Angular-convention commits | Sprint backlog, tech-lead review gate |
+| 5 Testing | The bats suite and the CI gate | Separate QA function, UAT, dedicated performance and penetration testers |
+| 6 Deployment | `build.sh` / `start.sh`; images rebuilt locally | Release manager, change management, training materials, rollback runbook — there are no production users |
+| 7 Maintenance | GitHub issues, ADR supersession | Incident dashboards, support organization |
+
+**4. Anti-goals.** Deliberately not built, at any level:
+
+- **Autonomous go/no-go.** The agent produces decision *material*; the human
+  holds the gate. Automating this makes it easy to rationalize starting
+  projects that should not start, which is the most expensive failure in the
+  whole cycle.
+- **Virtual-company role simulation.** See alternatives below.
+- **L3 parallel fan-out**, until L2 exists and demonstrates a bottleneck.
+
+## Consequences
+
+Scope is now bounded and the boundary is checkable rather than a matter of
+recollection. The existing `design` and `commit-convention` skills keep
+working unchanged — L1 extends them rather than replacing them. Cost stays
+near 4× rather than 15×. The approval gate stays human at both ends.
+
+Against that: L1 means an agent begins work without a human present at the
+start, so the approval gate moves entirely to the end of a run — worth
+watching, because a gate at only one end catches less than a gate at both.
+The phase mapping is a judgment recorded at one point in time. Declaring L3
+out of scope guarantees some genuinely parallelizable work will run
+sequentially, and that is accepted.
+
+This ADR assumes a single operator. If the project gains collaborators, the
+mapping in decision 3 stops being valid and this ADR should be superseded
+rather than quietly reinterpreted.
+
+## Alternatives considered
+
+**Chose:** a bounded L0→L1 ladder with a written L2 trigger.
+**Rejected:** MetaGPT/ChatDev-style multi-agent role simulation.
+**Why the rejected option is attractive:** it maps one-to-one onto the
+reference guide's role list, so the organizational chart becomes the
+architecture with no translation step — the design appears to write itself.
+**What breaks if you try it anyway:** the roles are precisely the part of
+the guide that does not apply to a single operator, so the mapping is to a
+fiction; the ~15× token cost buys parallelism this workload does not have;
+and the systems that pioneered it are cited far more often than they are
+run in production.
+
+**Chose:** declare an explicit stopping point and an explicit trigger.
+**Rejected:** leave the ladder open-ended.
+**Why the rejected option is attractive:** it costs nothing to write, keeps
+every option open, and avoids committing to a boundary that might later look
+wrong.
+**What breaks if you try it anyway:** scope then grows by default rather
+than by decision. An unstated boundary cannot be violated, so it cannot be
+enforced, and each level gets built because it is next rather than because
+it is needed.
+
+**Chose:** keep `sdlc_reference_guide.md` as-is and record the mapping here.
+**Rejected:** rewrite the guide to fit a single operator.
+**Why the rejected option is attractive:** a guide with nothing inapplicable
+in it is faster to read and harder to misapply.
+**What breaks if you try it anyway:** the guide is portable reference shared
+with other projects; forking it here produces two copies that drift. The
+phases are the general part and the mapping is the project-specific part —
+editing the general document to encode a local decision puts the knowledge
+in the wrong place.
+
+## References
+
+- [`sdlc_reference_guide.md`](../sdlc_reference_guide.md) — phase vocabulary and artifact lists
+- [`engineering-principles-by-lifecycle-phase.md`](../engineering-principles-by-lifecycle-phase.md) — "name your anti-goals", "prefer narrowing to accumulating"
+- [`docs-as-code-workflow.md`](../designs/docs-as-code-workflow.md) — Case A–E routing this decision preserves

--- a/docs/adr/002-planning-artifact-contract.md
+++ b/docs/adr/002-planning-artifact-contract.md
@@ -1,0 +1,132 @@
+# ADR 002 — Planning-phase artifact contract
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR 001](001-agentic-sdlc-scope.md) commits to L1: Planning runs headless,
+triggered by an event rather than by a person typing. A multi-step skill
+workflow needs step N's output to become step N+1's input, and there are
+only two ways to arrange that — implicitly, through conversation history, or
+explicitly, through written files.
+
+The implicit route works in an interactive session and fails silently
+outside one. Under `claude -p` there is no conversation for a later step to
+read; in a long session, early context is dropped and the failure surfaces
+as a quality problem rather than as the plumbing problem it is.
+
+A second concern points the same way. Content that lives in more than one
+place must be kept in sync, costs tokens on every read, and forces a reader
+to triangulate between sources. That is one root cause with two symptoms:
+context bloat for the agent, and comprehension overhead for a developer
+trying to understand just enough at 2am to make a fix. Both are solved by
+the same rule — one authoritative home per piece of information, everything
+else references it.
+
+Deciding this before the first skill is written is not tidiness. Every
+sub-skill's output section and every sub-skill's input instructions have to
+agree on paths and formats; defining that contract after two skills exist
+means retrofitting a shared interface.
+
+## Decision
+
+**1. Handoff is file-based, under `docs/planning/`.** Each sub-skill reads
+its inputs from paths and writes its output to a path. The orchestrator
+coordinates by path, never by conversation history.
+
+**2. Exactly one skill owns each path.** Any skill may read any path; a
+skill may write only the paths it owns. Initial allocation:
+
+| Path | Owner | Contains |
+|---|---|---|
+| `docs/planning/README.md` | every sub-skill updates its own row | Index: artifact, status, one-sentence description |
+| `docs/planning/scope.md` | `project-planning` (opening step) | Problem statement, constraints, explicit non-goals |
+| `docs/planning/prior-art.md` | `swe-prior-art-research` | Prior art, build-vs-adopt recommendation |
+| `docs/planning/feasibility.md` | `project-feasibility` | Technical / operational / financial feasibility, risk inventory |
+| `docs/planning/charter.md` | `project-planning` (closing step) | Charter and go/no-go decision material |
+
+**3. Every artifact carries frontmatter** with `status` (`Draft`,
+`Approved`, or `Superseded by <path>`), `date`, and `phase`. A reader must
+be able to tell a live artifact from a stale one without reading its body.
+
+**4. Every artifact is readable at two levels** — a TL;DR of at most three
+sentences at the top, full content below. A human scans five TL;DRs in under
+a minute; an agent reads the TL;DR to decide whether to retrieve the rest.
+
+**5. Templates carry hard section ceilings**, as template files rather than
+as advice in a SKILL.md. What does not fit in the template does not belong
+in that artifact; it belongs in a document with its own home.
+
+**6. No re-derivation.** If something was established in a prior step, the
+current step cites `path §section`, reads it, and builds on it — it never
+restates it. `See docs/planning/scope.md §2` is a citation. "See the
+planning documents" is not.
+
+**7. These rules are enforced by a test, not by a reviewer.**
+`tests/test_planning_artifacts.bats`, tagged `hostonly`, written when the
+first `docs/planning/` artifact lands. It asserts: every artifact has a row
+in the index; every artifact has a valid `status`; no artifact exceeds its
+template's ceilings; no skill declares an output path another skill owns.
+Rules 1–6 are prose, and prose is rung 2 of the enforcement ladder — a rule
+nothing can fail is a rule that stops holding the first time it is
+inconvenient. Naming the test here is what stops that from being the default
+outcome.
+
+## Consequences
+
+The handoff survives headless operation, which is what L1 requires. Every
+step's output is diffable, auditable, and resumable: if prior-art research
+finds something disqualifying, the run stops and the partial output is still
+readable without re-running anything. The index gives a 2am reader a single
+entry point instead of five files to triangulate.
+
+Against that: this is more files than a conversation-history design, and the
+ownership table in decision 2 is a maintenance surface that goes stale
+quietly when a skill is added or renamed — which is exactly why decision 7
+has a machine check it rather than trusting review. The ceilings in decision
+5 will sometimes be wrong and will need revisiting; a ceiling that is
+routinely worked around is worse than none, because it teaches everyone the
+contract is advisory.
+
+This assumes `docs/planning/` is committed. Artifacts for abandoned projects
+therefore stay in the tree, distinguished only by their `status` field. That
+is deliberate: a recorded no-go, with the reasoning that produced it, is the
+most reusable output the Planning phase has.
+
+## Alternatives considered
+
+**Chose:** explicit file-based handoff.
+**Rejected:** implicit handoff via conversation history.
+**Why the rejected option is attractive:** zero setup, no path contract to
+design or get wrong, and the model naturally sees everything a prior step
+produced without being told where to look.
+**What breaks if you try it anyway:** under `claude -p` there is no
+conversation to read from, so L1 cannot work at all; in long interactive
+sessions early context is silently dropped, and the resulting failure looks
+like the model reasoning poorly rather than like a missing input.
+
+**Chose:** hard ceilings in template files.
+**Rejected:** "keep output concise" instructions in each SKILL.md.
+**Why the rejected option is attractive:** one line per skill, no template
+files to write or maintain, and it reads as the obvious lightweight option.
+**What breaks if you try it anyway:** a conciseness instruction constrains
+one skill's output and does nothing to stop a later skill re-summarizing
+material an earlier one already wrote. Duplication has to be made
+structurally difficult, not discouraged.
+
+**Chose:** an index file every sub-skill updates.
+**Rejected:** rely on the directory listing and a naming convention.
+**Why the rejected option is attractive:** nothing to keep in sync, and no
+risk of the index itself going stale.
+**What breaks if you try it anyway:** a filename tells you what an artifact
+is called, not what it contains or whether it is current. The reader who
+needed one file still opens five, which is the problem the index exists to
+solve.
+
+## References
+
+- [ADR 001](001-agentic-sdlc-scope.md) — commits to L1, which is what forces an explicit handoff
+- [`docs-as-code-workflow.md`](../designs/docs-as-code-workflow.md) — document types and locations
+- [`engineering-principles-by-lifecycle-phase.md`](../engineering-principles-by-lifecycle-phase.md) — the enforcement ladder, and why prose is rung 2

--- a/docs/designs/docs-as-code-workflow.md
+++ b/docs/designs/docs-as-code-workflow.md
@@ -240,7 +240,18 @@ What constraints existed? What was tried before?>
 <What becomes easier, harder, or impossible as a result?
 Include both positive and negative consequences.
 Include any implicit assumptions the decision relies on.>
+
+## Alternatives considered
+<For each rejected option:
+**Chose:** … **Rejected:** … **Why the rejected option is attractive:** …
+**What breaks if you try it anyway:** …>
 ```
+
+The **Alternatives considered** section brings ADRs in line with the design
+document structure in Case C, which already records trade-offs. It is not
+optional: an option recorded without its appeal will be reinvented by the
+next person who finds it obvious, and because ADRs are never rewritten, an
+alternative left out at authoring time is unrecoverable.
 
 ADRs are **never rewritten**. If a decision is reversed, a new ADR is
 written with status `Supersedes ADR 00N`.

--- a/global-claude/skills/design/SKILL.md
+++ b/global-claude/skills/design/SKILL.md
@@ -242,7 +242,18 @@ What was decided? State it plainly and directly.
 ## Consequences
 What becomes easier, harder, or impossible as a result?
 Include both positive and negative consequences.
+
+## Alternatives considered
+For each rejected option:
+**Chose:** … **Rejected:** … **Why the rejected option is attractive:** …
+**What breaks if you try it anyway:** …
 ```
+
+The **Alternatives considered** section is not optional padding. An option
+recorded without its appeal will simply be reinvented by the next person who
+finds it obvious — the "why the rejected option is attractive" line is the
+one people skip and the one that does the work. Since ADRs are never
+rewritten, an alternative left unrecorded is unrecoverable.
 
 ADRs are **never rewritten**. If a decision is reversed, write a new
 ADR with `Status: Supersedes ADR 00N`.


### PR DESCRIPTION
Closes #38. Replaces #40, which was based on the #39 branch and got closed
automatically when that branch was deleted at merge. Not a content
conflict — this branch merges cleanly into `main`.

Adds the repository's first two ADRs, plus the `Alternatives considered`
section to the ADR template that had to land before them. Reasoning is in
the documents.
