### PR TITLE
fix(test): correct bats tag placement, and add the planning artifact scaffold

### DIFF
--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -1,0 +1,48 @@
+# Planning artifacts
+
+Index for the Planning phase. One row per artifact: what it is, who writes
+it, and whether it is current. A reader looking for one thing reads this
+table and then opens one file — that is what the index is for.
+
+The contract these artifacts follow is
+[ADR 002](../adr/002-planning-artifact-contract.md). This README does not
+restate it; it records the two implementation choices ADR 002 left open,
+and nothing else.
+
+## Index
+
+| Artifact | Status | Owner | Contains |
+|---|---|---|---|
+| `scope.md` | not yet written | `project-planning` | Problem statement, constraints, explicit non-goals |
+| `prior-art.md` | not yet written | `swe-prior-art-research` | Prior art, build-vs-adopt recommendation |
+| `feasibility.md` | not yet written | `project-feasibility` | Technical / operational / financial feasibility, risk inventory |
+| `charter.md` | not yet written | `project-planning` | Charter and go/no-go decision material |
+
+Every skill that writes an artifact updates its own row here, and only its
+own row. `tests/test_planning_artifacts.bats` fails if an artifact exists
+without one.
+
+Artifact names are code spans rather than links until the file exists — a
+markdown link to an unwritten artifact is a dangling reference, and D-1 in
+`tests/test_docs_integrity.bats` fails on it. The skill that writes an
+artifact turns its own name into a link at the same time it fills in the
+status.
+
+## Two choices ADR 002 left open
+
+**Templates live in `templates/`, artifacts live here.** ADR 002 decision 5
+requires templates to be files rather than advice inside a SKILL.md, but
+does not say where they go. Putting them in a subdirectory keeps the
+artifact paths exactly as decision 2 specifies, and keeps the index free of
+rows for files that are not artifacts.
+
+**Ceilings are counted in lines, not sentences.** ADR 002 decision 4 asks
+for a TL;DR of at most three sentences. The check counts lines instead,
+because splitting prose into sentences is unreliable — abbreviations and
+decimals both break it — and a check that misfires gets switched off, which
+is worse than a cruder check that holds. Each template declares its own
+ceilings as `ceiling-<section>:` keys in its frontmatter, so the numbers
+live next to the sections they govern rather than in the test.
+
+Three sentences remains the intent. The line ceiling is the mechanical
+proxy for it.

--- a/docs/planning/templates/charter.md
+++ b/docs/planning/templates/charter.md
@@ -1,0 +1,56 @@
+---
+artifact: docs/planning/charter.md
+owner: project-planning
+phase: planning
+ceiling-tldr: 6
+ceiling-recommendation: 12
+ceiling-evidence: 20
+ceiling-open-questions: 12
+ceiling-decision: 8
+---
+
+<!-- Template for docs/planning/charter.md. Copy, fill, delete these
+     comments.
+
+     Reads all three preceding artifacts and cites them by path and
+     section. This document aggregates; it does not re-derive. If a claim
+     here is not traceable to scope.md, prior-art.md, or feasibility.md,
+     it does not belong in the charter.
+
+     ADR 001 names autonomous go/no-go as an anti-goal. The Decision
+     section is filled in by a person, not by the skill that writes the
+     rest of this file. -->
+
+# Project charter
+
+## TL;DR
+
+<!-- At most three sentences. What is proposed, and what the evidence
+     points toward. -->
+
+## Recommendation
+
+<!-- Proceed, do not proceed, or proceed with a named condition. State
+     which, and what would change the answer. A recommendation that no
+     evidence could overturn is not a recommendation. -->
+
+## Evidence
+
+<!-- The findings this rests on, each cited to its source artifact and
+     section. Contradicting evidence goes here too — a charter that only
+     cites what supports the recommendation is an argument, not a summary. -->
+
+## Open questions
+
+<!-- What is still unresolved, and whether it blocks. Distinguish "unknown
+     and blocking" from "unknown and tolerable". -->
+
+## Decision
+
+<!-- Left blank by the skill. Filled in by a person, with a date.
+     Go / No-go / Deferred, and the reasoning in one or two lines.
+
+     A recorded no-go with its reasoning is the most reusable output this
+     phase produces — it stops the same idea being re-proposed from
+     scratch in six months. Do not delete this file on a no-go; set its
+     status and leave it. -->

--- a/docs/planning/templates/feasibility.md
+++ b/docs/planning/templates/feasibility.md
@@ -1,0 +1,57 @@
+---
+artifact: docs/planning/feasibility.md
+owner: project-feasibility
+phase: planning
+ceiling-tldr: 6
+ceiling-technical: 20
+ceiling-operational: 15
+ceiling-financial: 15
+ceiling-risk-inventory: 20
+ceiling-confidence-by-dimension: 12
+---
+
+<!-- Template for docs/planning/feasibility.md. Copy, fill, delete these
+     comments.
+
+     Reads docs/planning/scope.md and docs/planning/prior-art.md. Cite them
+     by path and section; do not restate their findings.
+
+     The three dimensions below do not have equal epistemic standing, and
+     presenting them at the same level of authority is this document's
+     characteristic failure. The confidence section exists to stop that. -->
+
+# Feasibility
+
+## TL;DR
+
+<!-- At most three sentences. Can this be built, by this team, for a
+     justifiable cost. -->
+
+## Technical
+
+<!-- Can it be built at all, given the constraints in scope.md? Verifiable
+     against prior art and the stack. Highest confidence of the three. -->
+
+## Operational
+
+<!-- Can *this* team build and run it — skills, access, capacity? Nothing
+     in the prior-art literature answers this; it is specific to here. -->
+
+## Financial
+
+<!-- Is the expected value worth the estimated effort? Assumption-laden by
+     nature. State the assumptions inline, because the number is only as
+     good as they are. -->
+
+## Risk inventory
+
+<!-- Top failure modes, one line each, each with a one-line mitigation.
+     Bulleted. No narrative — a risk that needs a paragraph is a scope
+     problem, not a risk. -->
+
+## Confidence by dimension
+
+<!-- One line per dimension above, saying how much weight it can carry.
+     Technical is usually verifiable; financial usually is not. A reader
+     who skips this will treat the weakest section as firmly as the
+     strongest. -->

--- a/docs/planning/templates/prior-art.md
+++ b/docs/planning/templates/prior-art.md
@@ -1,0 +1,41 @@
+---
+artifact: docs/planning/prior-art.md
+owner: swe-prior-art-research
+phase: planning
+ceiling-tldr: 6
+ceiling-findings: 60
+ceiling-build-vs-adopt: 15
+ceiling-confidence: 8
+---
+
+<!-- Template for docs/planning/prior-art.md. Copy, fill, delete these
+     comments.
+
+     Reads docs/planning/scope.md. Cite it as `docs/planning/scope.md
+     §Problem statement` — do not restate the problem here. -->
+
+# Prior art
+
+## TL;DR
+
+<!-- At most three sentences. Does something adequate already exist, and
+     what does that mean for building this. -->
+
+## Findings
+
+<!-- Per prior attempt: who did it, how, what tradeoffs they accepted, and
+     an adoption signal. Failure reports are the highest-value finding here
+     — "attempted X, abandoned because Y" saves more than a success story.
+     Distinguish established practice from one-off work. -->
+
+## Build vs adopt
+
+<!-- The recommendation and what it rests on. If nothing relevant exists,
+     say so plainly — absence of prior art is a finding, not a dead end,
+     and it usually means higher risk rather than opportunity. -->
+
+## Confidence
+
+<!-- Where the evidence is thin. A single blog post is not consensus, and
+     saying which claims rest on one source is what stops this document
+     from being read as more settled than it is. -->

--- a/docs/planning/templates/scope.md
+++ b/docs/planning/templates/scope.md
@@ -1,0 +1,45 @@
+---
+artifact: docs/planning/scope.md
+owner: project-planning
+phase: planning
+ceiling-tldr: 6
+ceiling-problem-statement: 12
+ceiling-constraints: 12
+ceiling-non-goals: 12
+ceiling-definition-of-done: 10
+---
+
+<!-- Template for docs/planning/scope.md. Copy, fill, delete these
+     comments. The frontmatter the artifact carries is status/date/phase/
+     owner — not the ceiling-* keys, which stay here.
+
+     What does not fit inside a ceiling does not belong in this artifact.
+     Move it to a document with its own home and cite it. -->
+
+# Scope
+
+## TL;DR
+
+<!-- At most three sentences. What is being proposed and what would make it
+     worth doing. A reader decides from this alone whether to read on. -->
+
+## Problem statement
+
+<!-- The problem in specific terms: who has it, what it costs them today,
+     and what "solved" would mean. Not the solution. -->
+
+## Constraints
+
+<!-- Hard constraints only — stack, timeline, budget, access, anything that
+     rules options out. A preference is not a constraint. -->
+
+## Non-goals
+
+<!-- What this deliberately does not do, and why. Silence reads as "not
+     yet", so anything a reader might reasonably assume is in scope but
+     is not belongs here explicitly. -->
+
+## Definition of done
+
+<!-- The observable condition that ends the work. Something that can be
+     checked, not a feeling of completion. -->

--- a/tests/test_build.bats
+++ b/tests/test_build.bats
@@ -24,8 +24,8 @@ teardown() {
     teardown_registered
 }
 
+# bats test_tags=fast
 @test "B-1: ./build.sh crypto builds base before crypto, both present" {
-    # bats test_tags=fast
     run bash "${SANDBOX_DIR}/build.sh" crypto
     [ "$status" -eq 0 ]
 
@@ -39,8 +39,8 @@ teardown() {
     engine_inspect claude-crypto > /dev/null 2>&1
 }
 
+# bats test_tags=fast
 @test "B-2: HOST_UID build-arg propagates to the resulting image's user" {
-    # bats test_tags=fast
     engine_build --build-arg HOST_UID=1234 -t claude-base:test "${SANDBOX_DIR}/base/"
     register_image "claude-base:test"
 
@@ -53,8 +53,8 @@ teardown() {
     [ "$id_output" = "1234" ]
 }
 
+# bats test_tags=slow
 @test "B-3: each Dockerfile builds cleanly standalone, without a prior full-build cache" {
-    # bats test_tags=slow
     engine_build --no-cache -t claude-base:test "${SANDBOX_DIR}/base/"
     register_image "claude-base:test"
 
@@ -75,8 +75,8 @@ teardown() {
     done
 }
 
+# bats test_tags=fast
 @test "B-4: build.sh does not pin any image reference to :latest" {
-    # bats test_tags=fast
     ! grep -q ":latest" "${SANDBOX_DIR}/build.sh"
     ! grep -q ":latest" "${SANDBOX_DIR}/start.sh"
 }

--- a/tests/test_config.bats
+++ b/tests/test_config.bats
@@ -38,8 +38,8 @@ _reg_fixture_dir() {
     cp "${SANDBOX_DIR}/start.sh" "${REG_TMPDIR}/start.sh"
 }
 
+# bats test_tags=fast, hostonly
 @test "C-1: env var overrides config.sh's value for the same variable" {
-    # bats test_tags=fast, hostonly
     run env ENGINE=docker bash -c '
         set -euo pipefail
         cd "'"${SANDBOX_DIR}"'"
@@ -53,8 +53,8 @@ _reg_fixture_dir() {
     [ "$output" = "docker" ]
 }
 
+# bats test_tags=fast, hostonly
 @test "C-2: config.sh overrides the hardcoded layer-1 default when no env var is set" {
-    # bats test_tags=fast, hostonly
     run bash -c '
         set -euo pipefail
         cd "'"${SANDBOX_DIR}"'"
@@ -66,8 +66,8 @@ _reg_fixture_dir() {
     [ "$output" != "sentinel-default-value" ]
 }
 
+# bats test_tags=fast, hostonly
 @test "C-3: config.sh's PROFILES matches the profile directories actually present" {
-    # bats test_tags=fast, hostonly
     run bash -c '
         set -euo pipefail
         cd "'"${SANDBOX_DIR}"'"
@@ -82,8 +82,8 @@ _reg_fixture_dir() {
     done
 }
 
+# bats test_tags=fast, hostonly
 @test "C-4: config.sh's PROFILE_BASE only references profiles PROFILES actually declares" {
-    # bats test_tags=fast, hostonly
     # Regression guard: a typo'd or stale base-dependency entry (e.g.
     # pointing at a renamed/removed profile) would silently no-op the
     # build.sh dependency lookup rather than fail loudly.
@@ -110,8 +110,8 @@ _reg_fixture_dir() {
     done <<< "$output"
 }
 
+# bats test_tags=fast, hostonly
 @test "C-5: build.sh rejects a target not present in config.sh's PROFILES, without touching an engine" {
-    # bats test_tags=fast, hostonly
     # No engine daemon required: dispatch to the "Unknown target" branch
     # happens before build.sh ever shells out to $ENGINE.
     run bash "${SANDBOX_DIR}/build.sh" definitely-not-a-real-profile
@@ -119,8 +119,8 @@ _reg_fixture_dir() {
     [[ "$output" == *"Unknown target"* ]]
 }
 
+# bats test_tags=fast, hostonly
 @test "C-6: build.sh and start.sh both source config.sh, not a re-copied literal list" {
-    # bats test_tags=fast, hostonly
     # Structural guard for the drift problem this design exists to fix:
     # both scripts must read PROFILES from the same sourced file rather
     # than hardcoding their own copies that could silently diverge again.
@@ -130,8 +130,8 @@ _reg_fixture_dir() {
 
 # C-7 onward: named project registry (docs/designs/named-project-registry.md)
 
+# bats test_tags=fast, hostonly
 @test "C-7: @name resolves to the registered path and its registry profile" {
-    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     mkdir -p "${REG_TMPDIR}/mylib"
     cat > "${REG_TMPDIR}/config.sh" <<EOF
@@ -145,8 +145,8 @@ EOF
     [[ "$output" == *"Image:    claude-crypto"* ]]
 }
 
+# bats test_tags=fast, hostonly
 @test "C-8: an explicit second argument overrides the registry's profile" {
-    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     mkdir -p "${REG_TMPDIR}/mylib"
     cat > "${REG_TMPDIR}/config.sh" <<EOF
@@ -159,8 +159,8 @@ EOF
     [[ "$output" == *"Image:    claude-systems"* ]]
 }
 
+# bats test_tags=fast, hostonly
 @test "C-9: an unknown @name exits non-zero and never reaches the engine" {
-    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     cat > "${REG_TMPDIR}/config.sh" <<EOF
 PROJECT_PATH[mylib]="${REG_TMPDIR}/mylib"
@@ -174,8 +174,8 @@ EOF
     [[ "$output" != *"Starting Squid proxy"* ]]  # no container was started
 }
 
+# bats test_tags=fast, hostonly
 @test "C-10: a name with a path but no profile is reported, not a 'set -u' crash" {
-    # bats test_tags=fast, hostonly
     # Regression guard for the two-array sync problem the design doc calls
     # out: PROJECT_PATH and PROJECT_PROFILE can drift apart, and the ':-'
     # guards at the read site must turn that into the intended error
@@ -193,8 +193,8 @@ EOF
     [[ "$output" != *"bad array subscript"* ]]
 }
 
+# bats test_tags=fast, hostonly
 @test "C-11: a bare name matching a registry entry is still treated as a path" {
-    # bats test_tags=fast, hostonly
     # The sigil boundary: from a directory containing a "mylib" subdirectory,
     # "./start.sh mylib" (no @, no second argument) must resolve as a plain
     # relative path and fall through to the base-profile default — not
@@ -214,8 +214,8 @@ EOF
     [[ "$output" == *"Image:    claude-base"* ]]
 }
 
+# bats test_tags=fast, hostonly
 @test "C-12: a name added only in config.local.sh resolves correctly" {
-    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     mkdir -p "${REG_TMPDIR}/localonly"
     : > "${REG_TMPDIR}/config.sh"   # no committed entries
@@ -231,8 +231,8 @@ EOF
     [[ "$output" != *"Warning:"* ]]
 }
 
+# bats test_tags=fast, hostonly
 @test "C-13: config.local.sh redefining a committed name is reverted and warned, not honored" {
-    # bats test_tags=fast, hostonly
     _reg_fixture_dir
     mkdir -p "${REG_TMPDIR}/committed-real" "${REG_TMPDIR}/attempted-override"
     cat > "${REG_TMPDIR}/config.sh" <<EOF

--- a/tests/test_docs_integrity.bats
+++ b/tests/test_docs_integrity.bats
@@ -40,7 +40,16 @@ _unresolved_markdown_links() {
         cd "$SANDBOX_DIR" || exit 1
         git ls-files '*.md' | while IFS= read -r f; do
             dir="$(dirname "$f")"
-            grep -oE '\]\([^)]+\)' "$f" 2>/dev/null \
+            # Strip fenced code blocks and inline code spans before looking
+            # for links. Documentation about markdown quotes markdown: the
+            # auto-memory design doc shows a MEMORY.md index entry inside a
+            # ```markdown fence and the `- [Title](file.md) — hook` grammar
+            # in a code span, neither of which is a reference to anything.
+            # Flagging those is the false-positive class that gets a check
+            # switched off, so it has to be excluded at the source.
+            awk '/^[[:space:]]*```/ { fence = !fence; next } !fence { print }' "$f" 2>/dev/null \
+            | sed 's/`[^`]*`//g' \
+            | grep -oE '\]\([^)]+\)' 2>/dev/null \
             | sed -E 's/^\]\(//; s/\)$//' \
             | while IFS= read -r link; do
                 case "$link" in
@@ -121,6 +130,40 @@ _malformed_adrs() {
     )
 }
 
+# Regression guard for a bug that silently disabled one test in every file
+# in this suite for its entire history.
+#
+# bats associates a "# bats test_tags=" comment with the NEXT @test it
+# sees. Every file here originally placed that comment as the first line
+# *inside* the test body, so each test was tagged with the previous test's
+# comment and the first test of every file ended up with no tags at all —
+# invisible to any --filter-tags run. That silently excluded D-1 (link
+# resolution), S-1 (the core Squid allowlist assertion) and R-1 (container
+# runs as non-root) from both CI and the documented fast-tier loop, while
+# every run still reported green. Confirmed by counting: --filter-tags
+# hostonly selected 15 of 17 tests on main.
+#
+# The tag comment must sit on the line above @test, which is the form
+# bats-core documents.
+_untagged_tests() {
+    (
+        cd "$SANDBOX_DIR" || exit 1
+        for f in tests/*.bats; do
+            [ -f "$f" ] || continue
+            grep -q '^#[[:space:]]*bats[[:space:]]*file_tags=' "$f" && continue
+            awk -v file="$f" '
+                /^@test / {
+                    if (prev !~ /^#[[:space:]]*bats[[:space:]]+test_tags=/) {
+                        line = $0; sub(/[[:space:]]*\{[[:space:]]*$/, "", line)
+                        print file ": " line " -- no tag comment on the line above"
+                    }
+                }
+                $0 !~ /^[[:space:]]*$/ { prev = $0 }
+            ' "$f"
+        done
+    )
+}
+
 _skill_dirs_without_manifest() {
     (
         cd "$SANDBOX_DIR" || exit 1
@@ -131,8 +174,8 @@ _skill_dirs_without_manifest() {
     )
 }
 
+# bats test_tags=fast, hostonly
 @test "D-1: every relative markdown link in a tracked document resolves" {
-    # bats test_tags=fast, hostonly
     run _unresolved_markdown_links
     [ "$status" -eq 0 ]
     if [ -n "$output" ]; then
@@ -142,8 +185,8 @@ _skill_dirs_without_manifest() {
     [ -z "$output" ]
 }
 
+# bats test_tags=fast, hostonly
 @test "D-2: every skill named in the global layer is committed to global-claude/skills/" {
-    # bats test_tags=fast, hostonly
     run _unresolved_skill_refs
     [ "$status" -eq 0 ]
     if [ -n "$output" ]; then
@@ -153,8 +196,8 @@ _skill_dirs_without_manifest() {
     [ -z "$output" ]
 }
 
+# bats test_tags=fast, hostonly
 @test "D-3: every ADR has a conforming heading and a valid Status" {
-    # bats test_tags=fast, hostonly
     run _malformed_adrs
     [ "$status" -eq 0 ]
     if [ -n "$output" ]; then
@@ -164,12 +207,23 @@ _skill_dirs_without_manifest() {
     [ -z "$output" ]
 }
 
+# bats test_tags=fast, hostonly
 @test "D-4: every directory under global-claude/skills/ contains a SKILL.md" {
-    # bats test_tags=fast, hostonly
     run _skill_dirs_without_manifest
     [ "$status" -eq 0 ]
     if [ -n "$output" ]; then
         echo "--- skill directories missing a manifest ---" >&2
+        echo "$output" >&2
+    fi
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "D-5: every @test carries a tag comment on the line above it" {
+    run _untagged_tests
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        echo "--- tests invisible to --filter-tags ---" >&2
         echo "$output" >&2
     fi
     [ -z "$output" ]

--- a/tests/test_global_layer.bats
+++ b/tests/test_global_layer.bats
@@ -32,8 +32,8 @@ teardown() {
     teardown_registered
 }
 
+# bats test_tags=fast
 @test "G-1: base global layer is applied to a new base-image session" {
-    # bats test_tags=fast
     register_container "$CONTAINER_NAME"
     run engine_run --rm --name "$CONTAINER_NAME" \
         --mount "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly" \
@@ -47,8 +47,8 @@ teardown() {
     diff <(echo "$cat_output") "${GLOBAL_BASE}/CLAUDE.md"
 }
 
+# bats test_tags=fast
 @test "G-2: overlay layer is applied alongside the base layer" {
-    # bats test_tags=fast
     register_container "$CONTAINER_NAME"
     run engine_run --rm --name "$CONTAINER_NAME" \
         --mount "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly" \
@@ -58,8 +58,8 @@ teardown() {
     [[ "$output" == *"both-present"* ]]
 }
 
+# bats test_tags=fast
 @test "G-3: /run/claude-global is not writable (OS-level readonly mount)" {
-    # bats test_tags=fast
     register_container "$CONTAINER_NAME"
     run engine_run --rm --name "$CONTAINER_NAME" \
         --mount "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly" \
@@ -68,8 +68,8 @@ teardown() {
     [[ "$output" == *"Read-only file system"* ]]
 }
 
+# bats test_tags=fast
 @test "G-4: a file written to ~/.claude/memory/ does not leak to the host source dir" {
-    # bats test_tags=fast
     register_container "$CONTAINER_NAME"
     engine_run --rm --name "$CONTAINER_NAME" \
         --mount "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly" \
@@ -78,8 +78,8 @@ teardown() {
     [ ! -e "${GLOBAL_BASE}/memory/leak-test.txt" ]
 }
 
+# bats test_tags=fast
 @test "G-5: a file written in one session is not visible from a second, concurrent session" {
-    # bats test_tags=fast
     name_a="test-claude-base-a-$$"
     name_b="test-claude-base-b-$$"
     register_container "$name_a"
@@ -98,8 +98,8 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
+# bats test_tags=fast
 @test "G-6: settings.json declares Write(/run/*) as an app-layer deny rule" {
-    # bats test_tags=fast
     # Full dynamic enforcement (an actual Claude Code turn attempting the
     # write and getting denied) would require driving a live agent turn,
     # which needs ANTHROPIC_API_KEY — forbidden by SDD §7.2. This test

--- a/tests/test_planning_artifacts.bats
+++ b/tests/test_planning_artifacts.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# test_planning_artifacts.bats — Group: Planning Artifact Contract
+#
+# The enforcement named in docs/adr/002-planning-artifact-contract.md
+# decision 7. That ADR's rules 1-6 are prose, which is rung 2 of the
+# enforcement ladder — a rule nothing can fail is a rule that stops holding
+# the first time it is inconvenient. These checks are what stop that from
+# being the default outcome.
+#
+# No engine daemon is required, so every test here is tagged hostonly and
+# runs in CI (see BUILDING.md, "Tag axes").
+#
+# Vacuity, stated plainly because it matters for how much these results
+# mean today: no artifact has been written yet, so P-2 and P-4 currently
+# have nothing to iterate over and pass trivially. P-1, P-3, P-5 and P-6
+# all assert against the four committed templates and carry real weight
+# now. P-2 and P-4 bind automatically the first time a skill writes to
+# docs/planning/ — no edit to this file required, which is the property
+# worth having.
+#
+# What this suite deliberately does NOT catch:
+#   - Whether an owner named in a template is a skill that actually
+#     exists. project-feasibility and project-planning are specified by
+#     ADR 002 and not yet built, so asserting existence today would fail
+#     on purpose-built absence. Tighten this once Phase 3 and 4 land;
+#     tests/test_docs_integrity.bats D-2 already does the equivalent for
+#     the global layer.
+#   - Whether a skill honours path ownership at write time. P-5 checks
+#     that the ownership table is unambiguous, not that anyone obeys it.
+#   - Whether a citation points at a section that exists. D-1 in
+#     test_docs_integrity.bats resolves the file; nothing resolves the
+#     "§Section" part.
+#   - Sentence counts. ADR 002 asks for a three-sentence TL;DR; the
+#     ceiling is counted in lines instead. Sentence splitting breaks on
+#     abbreviations and decimals, and a check that misfires gets switched
+#     off, which is worse than a cruder check that holds. See
+#     docs/planning/README.md.
+
+SANDBOX_DIR="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+PLANNING_DIR="${SANDBOX_DIR}/docs/planning"
+TEMPLATE_DIR="${PLANNING_DIR}/templates"
+
+# Heading text to ceiling-key slug: lowercase, drop anything that is not a
+# letter, digit or space, then spaces to hyphens. "TL;DR" -> tldr,
+# "Risk inventory" -> risk-inventory.
+_slug() {
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E 's/[^a-z0-9 -]//g; s/  */-/g; s/^-//; s/-$//'
+}
+
+# Frontmatter is the block between the first two --- lines.
+_frontmatter() {
+    awk 'NR==1 && $0=="---" {inb=1; next} inb && $0=="---" {exit} inb {print}' "$1"
+}
+
+_fm_value() {
+    _frontmatter "$1" | sed -n "s/^$2:[[:space:]]*//p" | head -1
+}
+
+# Artifacts are docs/planning/*.md excluding the index. Templates live one
+# level down and are never artifacts.
+_artifacts() {
+    find "$PLANNING_DIR" -maxdepth 1 -name '*.md' ! -name 'README.md' 2>/dev/null | sort
+}
+
+_templates() {
+    find "$TEMPLATE_DIR" -maxdepth 1 -name '*.md' 2>/dev/null | sort
+}
+
+# Non-blank, non-comment body lines under a "## <heading>" whose slug
+# matches $2, up to the next "## " or end of file. The heading itself is
+# not counted.
+_section_lines() {
+    awk -v want="$2" '
+        /^## / {
+            body = tolower(substr($0, 4))
+            gsub(/[^a-z0-9 -]/, "", body)
+            gsub(/ +/, "-", body)
+            sub(/^-/, "", body); sub(/-$/, "", body)
+            insec = (body == want)
+            next
+        }
+        !insec { next }
+        /<!--/ { incomment = 1 }
+        incomment { if (/-->/) incomment = 0; next }
+        /^[[:space:]]*$/ { next }
+        { n++ }
+        END { print n + 0 }
+    ' "$1"
+}
+
+_p1_templates_missing_declarations() {
+    for t in $(_templates); do
+        rel="${t#${SANDBOX_DIR}/}"
+        [ -n "$(_fm_value "$t" artifact)" ] || echo "${rel}: no 'artifact:' in frontmatter"
+        [ -n "$(_fm_value "$t" owner)" ]    || echo "${rel}: no 'owner:' in frontmatter"
+        _frontmatter "$t" | grep -q '^ceiling-' \
+            || echo "${rel}: declares no ceiling-* keys, so nothing constrains its sections"
+    done
+}
+
+_p2_invalid_status() {
+    for a in $(_artifacts); do
+        rel="${a#${SANDBOX_DIR}/}"
+        status="$(_fm_value "$a" status)"
+        case "$status" in
+            Draft|Approved|"Superseded by "*) ;;
+            *) echo "${rel}: status is '${status}' — expected Draft, Approved, or 'Superseded by <path>'" ;;
+        esac
+    done
+}
+
+_p3_missing_index_rows() {
+    index="${PLANNING_DIR}/README.md"
+    # Every artifact path a template claims, plus every artifact that exists.
+    { for t in $(_templates); do _fm_value "$t" artifact; done
+      for a in $(_artifacts); do echo "docs/planning/$(basename "$a")"; done
+    } | sort -u | while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        grep -q "$(basename "$path")" "$index" \
+            || echo "${path}: no row in docs/planning/README.md"
+    done
+}
+
+_p4_ceiling_violations() {
+    for a in $(_artifacts); do
+        rel="docs/planning/$(basename "$a")"
+        for t in $(_templates); do
+            [ "$(_fm_value "$t" artifact)" = "$rel" ] || continue
+            _frontmatter "$t" | sed -n 's/^ceiling-\([a-z0-9-]*\):[[:space:]]*\([0-9]*\)/\1 \2/p' \
+            | while read -r section limit; do
+                actual="$(_section_lines "$a" "$section")"
+                [ "$actual" -le "$limit" ] \
+                    || echo "${rel}: section '${section}' is ${actual} lines, ceiling is ${limit}"
+            done
+        done
+    done
+}
+
+_p5_duplicate_owners() {
+    for t in $(_templates); do _fm_value "$t" artifact; done \
+    | sort | uniq -d | while IFS= read -r dup; do
+        [ -n "$dup" ] && echo "${dup}: claimed by more than one template — ownership must be unambiguous"
+    done
+}
+
+_p6_dead_ceiling_keys() {
+    for t in $(_templates); do
+        rel="${t#${SANDBOX_DIR}/}"
+        _frontmatter "$t" | sed -n 's/^ceiling-\([a-z0-9-]*\):.*/\1/p' | while IFS= read -r key; do
+            found=""
+            while IFS= read -r heading; do
+                [ "$(_slug "$heading")" = "$key" ] && found=yes
+            done < <(grep '^## ' "$t" | sed 's/^## //')
+            [ -n "$found" ] || echo "${rel}: ceiling-${key} names no '## ' section in this template"
+        done
+    done
+}
+
+_report() {
+    if [ -n "$1" ]; then
+        echo "--- $2 ---" >&2
+        echo "$1" >&2
+    fi
+}
+
+# bats test_tags=fast, hostonly
+@test "P-1: every template declares an artifact path, an owner, and ceilings" {
+    run _p1_templates_missing_declarations
+    [ "$status" -eq 0 ]
+    _report "$output" "templates missing declarations"
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "P-2: every planning artifact carries a valid status" {
+    run _p2_invalid_status
+    [ "$status" -eq 0 ]
+    _report "$output" "artifacts with an invalid status"
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "P-3: every artifact path has a row in the index" {
+    run _p3_missing_index_rows
+    [ "$status" -eq 0 ]
+    _report "$output" "artifact paths missing from the index"
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "P-4: no artifact section exceeds its template's ceiling" {
+    run _p4_ceiling_violations
+    [ "$status" -eq 0 ]
+    _report "$output" "sections over ceiling"
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "P-5: no artifact path is claimed by more than one template" {
+    run _p5_duplicate_owners
+    [ "$status" -eq 0 ]
+    _report "$output" "artifact paths with ambiguous ownership"
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "P-6: every declared ceiling names a section that exists" {
+    run _p6_dead_ceiling_keys
+    [ "$status" -eq 0 ]
+    _report "$output" "ceiling keys naming no section"
+    [ -z "$output" ]
+}

--- a/tests/test_runtime_posture.bats
+++ b/tests/test_runtime_posture.bats
@@ -34,8 +34,8 @@ teardown() {
     [ -n "${R8_TMPDIR:-}" ] && [ -d "$R8_TMPDIR" ] && rm -rf "$R8_TMPDIR" || true
 }
 
+# bats test_tags=fast
 @test "R-1: container runs as claude-agent, never root" {
-    # bats test_tags=fast
     register_container "$CONTAINER_NAME"
     run engine_run --rm --name "$CONTAINER_NAME" claude-base whoami
     [ "$status" -eq 0 ]
@@ -46,8 +46,8 @@ teardown() {
     [ "$whoami_output" = "claude-agent" ]
 }
 
+# bats test_tags=fast
 @test "R-2: all capabilities are dropped on a running container" {
-    # bats test_tags=fast
     #
     # Docker preserves the literal "ALL" token passed via --cap-drop in
     # .HostConfig.CapDrop, but Podman normalizes/expands it and does not
@@ -64,8 +64,8 @@ teardown() {
     [ "$cap_eff" = "0000000000000000" ]
 }
 
+# bats test_tags=fast
 @test "R-3: no-new-privileges security option is active" {
-    # bats test_tags=fast
     register_container "$CONTAINER_NAME"
     engine_run -d --rm --name "$CONTAINER_NAME" --security-opt=no-new-privileges claude-base sleep 30
 
@@ -74,8 +74,8 @@ teardown() {
     [[ "$output" == *"no-new-privileges"* ]]
 }
 
+# bats test_tags=fast
 @test "R-4: unknown image is rejected before any container starts" {
-    # bats test_tags=fast
     run bash "${SANDBOX_DIR}/start.sh" "$SCRATCH_FIXTURE" nonexistent-image
     [ "$status" -ne 0 ]
     [[ "$output" == *"unknown image"* ]]
@@ -83,8 +83,8 @@ teardown() {
     ! engine_ps -a --filter "name=claude-scratch-project-" --format '{{.Names}}' | grep -q .
 }
 
+# bats test_tags=fast
 @test "R-5: missing (unbuilt) image is rejected with build guidance, not a silent pull" {
-    # bats test_tags=fast
     target=""
     for candidate in crypto systems research; do
         if ! engine_inspect "claude-${candidate}" > /dev/null 2>&1; then
@@ -108,8 +108,8 @@ teardown() {
     ! engine_inspect "claude-${target}" > /dev/null 2>&1
 }
 
+# bats test_tags=fast
 @test "R-6: cgroups memory limit is actually enforced, not just accepted" {
-    # bats test_tags=fast
     #
     # Regression test for a real finding (podman-migration.md §6.2-D,
     # claude_code_security_plan.md Change 17): under a WSL2 host without
@@ -141,8 +141,8 @@ teardown() {
     [ "$status" -eq 137 ]
 }
 
+# bats test_tags=fast
 @test "R-7: /workspace bind mount is genuinely readable and writable under SELinux" {
-    # bats test_tags=fast
     #
     # Regression test for a real finding (claude_code_security_plan.md
     # Change 19, podman-migration.md §6.2 Tampering follow-up): a bind
@@ -187,8 +187,8 @@ teardown() {
     [ "$(cat "${R7_TMPDIR}/written.txt")" = "written-from-container" ]
 }
 
+# bats test_tags=fast
 @test "R-8: relabel=shared (not private) allows two concurrent sessions on the same host path" {
-    # bats test_tags=fast
     #
     # R-7 alone doesn't validate the shared-vs-private design decision in
     # Change 19 — a relabel=private (:Z) mount would also pass a

--- a/tests/test_squid_isolation.bats
+++ b/tests/test_squid_isolation.bats
@@ -95,40 +95,40 @@ proxy_logs() {
     engine_logs "$(cat "${BATS_FILE_TMPDIR}/proxy_name")" 2>&1
 }
 
+# bats test_tags=slow
 @test "S-1: request to an allowed domain succeeds (TCP_TUNNEL/200 in the access log)" {
-    # bats test_tags=slow
     run proxy_logs
     [[ "$output" == *"TCP_TUNNEL/200"* ]]
 }
 
+# bats test_tags=slow
 @test "S-2: request to a blocked domain is refused (TCP_DENIED/403)" {
-    # bats test_tags=slow
     run proxy_logs
     [[ "$output" == *"TCP_DENIED"* ]] || [[ "$output" == *"/403"* ]]
 }
 
+# bats test_tags=slow
 @test "S-3: every attempted connection produces exactly one parseable access log line" {
-    # bats test_tags=slow
     run proxy_logs
     [ "$status" -eq 0 ]
     line_count=$(echo "$output" | grep -cE '^[0-9]+\.[0-9]+[[:space:]]+[0-9]+[[:space:]]+[0-9.]+[[:space:]]+\S+/[0-9]+')
     [ "$line_count" -ge 5 ]
 }
 
+# bats test_tags=slow
 @test "S-4: request to docs.anthropic.com (issue #32 Reference tier addition) succeeds" {
-    # bats test_tags=slow
     run proxy_logs
     [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+docs\.anthropic\.com:443 ]]
 }
 
+# bats test_tags=slow
 @test "S-5: request to code.claude.com (issue #32 Reference tier addition) succeeds" {
-    # bats test_tags=slow
     run proxy_logs
     [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+code\.claude\.com:443 ]]
 }
 
+# bats test_tags=slow
 @test "S-6: request to mintcdn.com (issue #32 dstdom_regex CDN exception) succeeds" {
-    # bats test_tags=slow
     run proxy_logs
     [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+mintcdn\.com:443 ]]
 }

--- a/tests/test_toolchain_smoke.bats
+++ b/tests/test_toolchain_smoke.bats
@@ -23,8 +23,8 @@ teardown() {
     teardown_registered
 }
 
+# bats test_tags=slow
 @test "T-1: crypto profile — softhsm2-util and p11-kit are functional" {
-    # bats test_tags=slow
     if ! engine_inspect claude-crypto > /dev/null 2>&1; then
         echo "claude-crypto image not found — build it first with: ./build.sh crypto" >&2
         return 1
@@ -36,8 +36,8 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+# bats test_tags=slow
 @test "T-2: systems profile — minimal CMake project builds and links against GTest" {
-    # bats test_tags=slow
     if ! engine_inspect claude-systems > /dev/null 2>&1; then
         echo "claude-systems image not found — build it first with: ./build.sh systems" >&2
         return 1
@@ -51,8 +51,8 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+# bats test_tags=slow
 @test "T-3: research profile — minimal LaTeX document compiles via latexmk" {
-    # bats test_tags=slow
     if ! engine_inspect claude-research > /dev/null 2>&1; then
         echo "claude-research image not found — build it first with: ./build.sh research" >&2
         return 1


### PR DESCRIPTION
Closes #48 and #49.

Two changes that belong together only because the first is what makes the
second's test results mean anything: the tag fix is why `P-1` runs at all.

This is the first CI run that executes `D-1`, `C-1` and `P-1`.
