### PR TITLE
fix(hooks): match tool-generated attribution as a class

### DIFF
--- a/global-claude/hooks/commit-msg
+++ b/global-claude/hooks/commit-msg
@@ -1,7 +1,63 @@
 #!/usr/bin/env bash
 # Installed by claude-sandbox global layer
-if grep -qi "^Co-Authored-By:" "$1"; then
-    echo "ERROR: Co-Authored-By lines are not allowed in this repository." >&2
-    echo "       Remove the trailer and commit again." >&2
+#
+# Rejects tool-generated attribution in commit messages.
+#
+# The rule is deliberately broad. The first version of this hook matched the
+# single literal "Co-Authored-By:" that was known when it was written, so a
+# "Generated with [Claude Code]" footer passed it unchallenged. A rule that
+# matches only the example it was written against is not a rule; the same
+# failure and the same fix are recorded for D-2 in
+# tests/test_docs_integrity.bats.
+#
+# Two shapes are rejected:
+#   1. Attribution trailers — <Word>-By: at the start of a line.
+#   2. Generation footers   — "generated with/by" at the start of a line,
+#      after any leading punctuation or emoji.
+#
+# Shape 2 is anchored at the line start on purpose. Attribution footers are
+# always line-leading; an unanchored match would reject body prose that
+# happens to mention a generated file.
+
+set -u
+
+MSG_FILE="$1"
+
+# Legitimate git trailers that match shape 1. Listed here rather than
+# narrowing the pattern: every entry is a deliberate exemption and shows up
+# as one in a diff, which is the point. Compared lowercased.
+ALLOWED_TRAILERS="signed-off-by reported-by reviewed-by tested-by acked-by suggested-by requested-by"
+
+reject() {
+    echo "ERROR: $1" >&2
+    echo "       Tool-generated attribution is not allowed in this repository." >&2
+    echo "       Remove the line and commit again." >&2
     exit 1
-fi
+}
+
+# git has not stripped comment lines yet when commit-msg runs, so a commented
+# example of a forbidden trailer would otherwise be rejected.
+BODY="$(grep -v '^#' "$MSG_FILE" || true)"
+
+while IFS= read -r line; do
+    [ -n "$line" ] || continue
+
+    trailer="$(printf '%s\n' "$line" \
+        | sed -n 's/^\([A-Za-z][A-Za-z]*\(-[A-Za-z][A-Za-z]*\)*-[Bb]y\):.*/\1/p' \
+        | tr '[:upper:]' '[:lower:]')"
+
+    if [ -n "$trailer" ]; then
+        case " ${ALLOWED_TRAILERS} " in
+            *" ${trailer} "*) : ;;
+            *) reject "attribution trailer '${trailer}:' is not allowed." ;;
+        esac
+    fi
+
+    if printf '%s\n' "$line" | grep -qiE '^[^[:alpha:]]*generated[[:space:]]+(with|by)[[:space:]]'; then
+        reject "generation footer is not allowed."
+    fi
+done <<EOF
+${BODY}
+EOF
+
+exit 0

--- a/global-claude/skills/commit-hook-setup/SKILL.md
+++ b/global-claude/skills/commit-hook-setup/SKILL.md
@@ -2,9 +2,9 @@
 name: commit-hook-setup
 description: >
   Install or verify the commit-msg hook in /workspace. Invoke when the
-  entrypoint log shows "hook already present" and Co-Authored-By
-  enforcement is not yet in place, or when asked to set up or inspect
-  commit enforcement.
+  entrypoint log shows "hook already present" and attribution-trailer
+  enforcement is not yet in place or may be stale, or when asked to set up
+  or inspect commit enforcement.
 ---
 
 # Commit Hook Setup
@@ -25,13 +25,44 @@ cat /workspace/.git/hooks/commit-msg 2>/dev/null || echo "(no hook present)"
 
 **No hook present** → proceed to Step 3. Ask the operator to confirm before writing.
 
-**Hook present and contains `Co-Authored-By` check** → compliant. Report and stop.
+**Hook present** → do not judge it by reading it. A hook containing the words
+you expect can still accept the messages it exists to reject: the first
+version of this hook matched one literal trailer and let every other form of
+tool attribution through, and a copy installed before that fix is
+indistinguishable by eye. Run Step 2a and decide on what it does.
 
-**Hook present but does not contain the check** → show the existing content to the
-operator. Ask them to choose:
-  a) Replace with the standard hook (loses existing logic)
-  b) Append the Co-Authored-By check to the existing hook
-  c) Leave as-is (enforcement gap — note it explicitly)
+## Step 2a — Probe the installed hook
+
+```bash
+probe() {
+    printf 'test: probe\n\n%s\n' "$2" > /tmp/hook-probe
+    if bash /workspace/.git/hooks/commit-msg /tmp/hook-probe > /dev/null 2>&1; then
+        [ "$1" = accept ] && echo "ok:   accepted — $2" || echo "GAP: accepted — $2"
+    else
+        [ "$1" = reject ] && echo "ok:   rejected — $2" || echo "OVER-BROAD: rejected — $2"
+    fi
+}
+
+probe reject 'Co-Authored-By: Someone <a@b.c>'
+probe reject 'Generated with SomeTool'
+probe accept 'Signed-off-by: Real Person <a@b.c>'
+```
+
+**Every line reports `ok:`** → compliant. Report and stop.
+
+**Any line reports `GAP:`** → the installed hook is stale. It predates the
+widening of the pattern and misses at least one shape of tool attribution.
+
+**Any line reports `OVER-BROAD:`** → the installed hook rejects a legitimate
+git trailer. That is the failure mode that gets a hook disabled, so treat it
+as urgent as a gap.
+
+For either, show the operator the hook's content and the probe output, then
+ask them to choose:
+
+  a) Replace with the standard hook (loses any custom logic in the existing one)
+  b) Merge the standard hook's checks into the existing one
+  c) Leave as-is — an enforcement gap; state which probes failed
 
 Never overwrite silently.
 
@@ -42,8 +73,5 @@ cp ~/.claude/hooks/commit-msg /workspace/.git/hooks/commit-msg
 chmod +x /workspace/.git/hooks/commit-msg
 ```
 
-Verify:
-```bash
-ls -la /workspace/.git/hooks/commit-msg
-cat /workspace/.git/hooks/commit-msg
-```
+Verify by re-running Step 2a. `ls -la` and `cat` confirm the file arrived;
+only the probes confirm it enforces anything.


### PR DESCRIPTION
Closes #45.

The hook matched one literal trailer, so a "Generated with [Claude Code]"
footer passed it unchallenged. Both commits are the same fix at two layers:
the pattern, and the skill that certified a hook by reading it rather than
running it.

Verified against 14 message fixtures covering both directions — the footer is
caught, and `Signed-off-by` and body prose mentioning a generated file are not.
Pointed at this repository's own installed hook, the new probe reports the gap
that motivated #45's second half, now tracked separately.
