### PR TITLE
feat(global-layer): place behavioural rules by precision, and measure the layer

### DIFF
--- a/docs/adr/003-where-a-behavioural-rule-goes.md
+++ b/docs/adr/003-where-a-behavioural-rule-goes.md
@@ -1,0 +1,153 @@
+# ADR 003 — Where a behavioural rule goes
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #42 asks whether engineering principles belong in the injected
+`global-claude/CLAUDE.md` or in a skill invoked when relevant, and explicitly
+declines to answer: "that is an argument worth making explicitly rather than
+assuming, because the same reasoning would justify putting anything there."
+The question gates #42 and #43 — nothing can be written into `CLAUDE.md` until
+it is settled — and it recurs for every rule proposed afterwards.
+
+Two facts, both established after #42 was written, change the framing.
+
+**The informal channel does not exist.** The session container runs `--rm`
+(`start.sh:301`) and mounts nothing under `~/.claude`; G-4 and G-5
+(`tests/test_global_layer.bats:71-99`) assert that isolation deliberately.
+Anything an agent records to memory is destroyed at session exit. `CLAUDE.md`
+and skills are not merely the better channels — they are the only ones that
+survive a session boundary.
+
+**Two of #42's five candidate principles are already carried.** An audit
+against the tree at `80618e7`:
+
+| Candidate (§ of `docs/engineering-principles-by-lifecycle-phase.md`) | Existing carrier |
+|---|---|
+| Name anti-goals; silence reads as "not yet" (§Design) | `docs/planning/templates/scope.md:36-40`, verbatim; also `templates/charter.md:20`, `docs/adr/001-agentic-sdlc-scope.md:29` |
+| Record rejections, including why the rejected option was attractive (§Design) | `global-claude/skills/design/SKILL.md:246-256`; `docs/designs/docs-as-code-workflow.md:244-254` |
+| Spend length only on what the diff cannot carry (§Part I.4) | none |
+| Grep for readers, not definitions (§Part I.3) | none |
+| A gate never observed failing is not known to be a gate (§Part I.1) | none |
+
+Writing the first two into `CLAUDE.md` would duplicate text that already sits
+closer to the moment of authorship than `CLAUDE.md` does — which is the defect
+ADR 002 decision 6 names, appearing in the file that decision governs.
+
+So the binary in #42 is incomplete. There is a third placement, and it is the
+one already working.
+
+## Decision
+
+**1. Three placements, ranked by precision. Use the most specific that fits.**
+
+| Rung | Placement | Loads | Use when |
+|---|---|---|---|
+| 1 | Artifact template or format spec | When the artifact is authored | An artifact format already exists that the rule constrains |
+| 2 | Skill | Description always; body on invocation | The applicable moment has a nameable trigger, and the rule needs a procedure rather than a sentence |
+| 3 | `CLAUDE.md` | Every session, always | The moment cannot be named as a discrete trigger |
+
+**2. A rule earns rung 3 only by failing rungs 1 and 2.** Always-on placement
+is not granted on the strength of the rule; it is what remains when the rule
+cannot be attached to an artifact or a trigger. This is the admission criterion
+#42 asked for, and it constrains additions whether or not a line ceiling
+exists.
+
+**3. Rung 2 is paid for in the description, not the body.** A skill's
+`description` is in context every session; only the body is deferred. Both
+rungs therefore cost roughly one always-on line — rung 2 buys a full procedure
+for that line, rung 3 buys one sentence. Prefer rung 2 whenever the rule needs
+more than a sentence, and write the trigger into the description sharply enough
+to fire, because an unfired skill is the failure mode that makes rung 2 worse
+than rung 3.
+
+**4. No restatement.** If a principle already has a carrier, cite `path
+§section` and stop. ADR 002 decision 6 applies to `CLAUDE.md` itself.
+
+**5. Applied to #42's five candidates:**
+
+| Principle | Placement | Work |
+|---|---|---|
+| Spend length only on what the diff cannot carry | Rung 3 | Already scheduled — this is #43's output-cost rule |
+| Grep for readers, not definitions | Rung 2 | New skill; own issue |
+| A gate never observed failing is not known to be a gate | Rung 2 | Same skill; own issue |
+| Name anti-goals | Rung 1, carried | Cite `templates/scope.md`; write nothing |
+| Record rejections and their appeal | Rung 1, carried | Cite `design/SKILL.md`; write nothing |
+
+The two rung-2 principles plausibly share one skill — both say *check the
+mechanism, do not trust its presence*, one for a gate and one for a definition.
+Whether they do is a design question for that issue, not this one.
+
+## Consequences
+
+#42 shrinks to almost nothing in `CLAUDE.md`: one line, which #43 already
+supplies. That matters for ordering: a size ceiling has to be set against content that
+already exists, or the change that introduces the ceiling breaches it. The
+ceiling can now be set against a file that is not about to absorb four more
+rules.
+
+`CLAUDE.md` gains a falsifiable admission test. "Does this fail rungs 1 and 2?"
+is answerable by inspection — is there a template, is there a trigger — where
+"is this important enough" is not. The recurrence #42 predicts is not
+prevented, but arguing for an addition now requires showing no artifact and no
+trigger exists, which is a claim that can be checked and refused.
+
+Against that: **the ladder's weakest rung is the one it prefers.** A rung-1
+rule fires only if the template is used; a rung-2 rule fires only if the
+trigger is recognised. Both fail silently, and neither failure is observable —
+which is the enforcement-ladder defect (§Part I.1) reproduced inside the
+mechanism meant to place it. Decision 3 mitigates rung 2 by loading the trigger
+always; rung 1 has no equivalent mitigation and relies on the template being
+reached for at all.
+
+There is direct evidence for that risk. On 2026-09-02 an analysis deliverable
+was produced as a styled HTML page rather than Markdown, in a docs-as-code
+repository, with no skill invoked and no moment at which a trigger would have
+fired. That is the density principle failing with no carrier at any rung — the
+observation that produced #43's format rule, and the reason that particular
+principle is placed at rung 3 rather than deferred to a skill.
+
+This decision assumes skill descriptions are loaded into context every session
+while bodies are not. Decision 3's economics depend on it entirely. If that
+changes, rung 2 collapses into rung 1's failure mode and the ladder needs
+revisiting.
+
+## Alternatives considered
+
+**Chose:** the three-rung ladder.
+**Rejected:** the binary `CLAUDE.md`-versus-skill as #42 posed it.
+**Why the rejected option is attractive:** it is the question actually asked,
+it needs no new vocabulary, and two options resolve faster than three.
+**What breaks if you try it anyway:** two of the five candidates have no
+correct home under it, so they get written into `CLAUDE.md` as duplicates of
+`templates/scope.md` and `design/SKILL.md` — inflating the file #42 exists to
+protect, and breaching ADR 002 decision 6 in the process.
+
+**Chose:** admission by failing the lower rungs.
+**Rejected:** an allowlist of topics permitted in `CLAUDE.md`.
+**Why the rejected option is attractive:** a list is enumerable, greppable, and
+would look like moving the rule off rung 2 of the enforcement ladder — the
+direction #37 and #49 have both pushed.
+**What breaks if you try it anyway:** the list has no principled bound, so
+every proposed rule becomes an argument to extend it. The check would pass
+while the file grows, which is worse than no check, because it certifies the
+outcome it was built to prevent.
+
+**Chose:** audit the five candidates for existing carriers before writing any.
+**Rejected:** write all five into `CLAUDE.md`, prune later.
+**Why the rejected option is attractive:** it is #42 as written, and judging
+duplication is easier once the lines sit next to each other.
+**What breaks if you try it anyway:** the ceiling gets set against the inflated
+file, so the duplication becomes the permanent baseline, and the pruning pass
+is never forced because nothing fails.
+
+## References
+
+- Issue #42 — distil the engineering principles into the injected `CLAUDE.md`
+- Issue #43 — output-cost discipline, mechanism or rule
+- ADR 002 §Decision 6 — no re-derivation; cite `path §section`
+- `docs/engineering-principles-by-lifecycle-phase.md` §Part I.1, §Part I.3,
+  §Part I.4, §Design

--- a/docs/designs/global-layer-injection.md
+++ b/docs/designs/global-layer-injection.md
@@ -394,6 +394,9 @@ _Controls:_
 - Claude Code's context window cost is bounded by the total size of injected Markdown files.
   A 200-line `CLAUDE.md` and five skills of similar size costs roughly 8,000–10,000 tokens —
   significant but acceptable. Operators should keep the global layer lean.
+- D-6 and D-7 in `tests/test_docs_integrity.bats` hold that lean-ness to a number: 200
+  lines for `CLAUDE.md`, 3000 across the layer. Until they were added this control was
+  named here and enforced nowhere, so no growth was ever observed to breach it.
 
 ### 5.3 Updated STRIDE coverage map
 
@@ -403,7 +406,7 @@ _Controls:_
 | **Tampering (T)** | Container filesystem scope + `permissions.deny` | Readonly mounts at `/run/`; `Write(/run/*)` deny rule |
 | **Repudiation (R)** | Docker + Squid + Claude logs | Entrypoint stdout logs; git history of `global-claude/` |
 | **Information Disclosure (I)** | Network allowlist; secrets not mounted | Global layer contains no secrets by design |
-| **Denial of Service (D)** | `--memory` and `--cpus` limits | Global layer size discipline |
+| **Denial of Service (D)** | `--memory` and `--cpus` limits | Global layer size discipline, enforced by D-6 and D-7 |
 | **Elevation of Privilege (E)** | Non-root user; `--cap-drop=ALL`; `--no-new-privileges` | Entrypoint runs as `claude-agent`; no sudo in script |
 
 ---

--- a/global-claude/CLAUDE.md
+++ b/global-claude/CLAUDE.md
@@ -19,6 +19,14 @@
   creating issues
 - See docs/designs/docs-as-code-workflow.md §4 for case selection
 
+## Output discipline
+- Spend length only on what the diff or a linked document cannot carry;
+  restating a linked document is not earned length
+  (docs/engineering-principles-by-lifecycle-phase.md §Part I.4)
+- Default to Markdown for prose deliverables. A richer format — HTML, a
+  published page — is earned when Markdown cannot carry the content
+  (interaction, charts, layout), or when it was asked for
+
 ## Interpreter discipline
 - Before creating a venv or any build artifact in /workspace, verify the
   interpreter or toolchain version is already baked into the image

--- a/global-claude/CLAUDE.md
+++ b/global-claude/CLAUDE.md
@@ -7,10 +7,17 @@
 ## Git Workflow
 - Follow Angular commit convention (see `commit-convention` skill)
 - Never commit on `main`; create a branch first
-- Do not include "Co-Authored-By" lines in commits
+- Do not include tool-generated attribution trailers in commits
 - Avoid command substitution `$()` in commit messages
-- Prefer single-file atomic commits; use multi-file commits only when changes are tightly coupled
-- Always ask before staging and committing any change
+- One logical change per commit
+- Case A and B: commit without asking
+- Case C: commit without asking when that individual commit would qualify
+  as Case A or B on its own; confirm for the design-document commit and
+  the closing commit
+- Case D and E: always confirm, however small the change looks
+- Committing without asking never extends to pushing, opening PRs, or
+  creating issues
+- See docs/designs/docs-as-code-workflow.md §4 for case selection
 
 ## Interpreter discipline
 - Before creating a venv or any build artifact in /workspace, verify the

--- a/tests/test_docs_integrity.bats
+++ b/tests/test_docs_integrity.bats
@@ -174,6 +174,44 @@ _skill_dirs_without_manifest() {
     )
 }
 
+# The global layer is copied into ~/.claude in every session, so its size is
+# a permanent context-window cost paid by every task. docs/designs/
+# global-layer-injection.md §5.2 names "Global layer size discipline" as the
+# Denial of Service control and puts a 200-line CLAUDE.md at "significant but
+# acceptable" — but named the control without giving it a mechanism, so
+# nothing has ever observed it fail. D-6 and D-7 are that mechanism.
+#
+# Ceilings are lines, not bytes. The same directory measures 66K, 123K or
+# 160K depending on whether you sum file contents, count directory entries,
+# or count allocated blocks; a ceiling whose unit is ambiguous either never
+# fires or fires when a subdirectory is added. docs/planning/README.md made
+# the same call for the artifact templates and for the same reason.
+#
+# The §5.2 illustration (a 200-line CLAUDE.md plus five skills of similar
+# size, so roughly 1200 lines) is already exceeded at 1566. D-7 is therefore
+# set above current usage deliberately: it is a bound on unnoticed growth,
+# not a target to shrink toward.
+_CLAUDE_MD_MAX_LINES=200
+_GLOBAL_LAYER_MAX_LINES=3000
+
+_claude_md_over_ceiling() {
+    (
+        cd "$SANDBOX_DIR" || exit 1
+        n=$(wc -l < global-claude/CLAUDE.md)
+        [ "$n" -le "$_CLAUDE_MD_MAX_LINES" ] \
+            || echo "global-claude/CLAUDE.md: ${n} lines exceeds the ${_CLAUDE_MD_MAX_LINES}-line ceiling"
+    )
+}
+
+_global_layer_over_ceiling() {
+    (
+        cd "$SANDBOX_DIR" || exit 1
+        n=$(find global-claude -type f -exec cat {} + | wc -l)
+        [ "$n" -le "$_GLOBAL_LAYER_MAX_LINES" ] \
+            || echo "global-claude/: ${n} lines across all files exceeds the ${_GLOBAL_LAYER_MAX_LINES}-line ceiling"
+    )
+}
+
 # bats test_tags=fast, hostonly
 @test "D-1: every relative markdown link in a tracked document resolves" {
     run _unresolved_markdown_links
@@ -224,6 +262,28 @@ _skill_dirs_without_manifest() {
     [ "$status" -eq 0 ]
     if [ -n "$output" ]; then
         echo "--- tests invisible to --filter-tags ---" >&2
+        echo "$output" >&2
+    fi
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "D-6: global-claude/CLAUDE.md stays within its line ceiling" {
+    run _claude_md_over_ceiling
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        echo "--- injected into every session; see docs/adr/003 for what earns a line ---" >&2
+        echo "$output" >&2
+    fi
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "D-7: the global layer as a whole stays within its line ceiling" {
+    run _global_layer_over_ceiling
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        echo "--- every line here is context cost in every session ---" >&2
         echo "$output" >&2
     fi
     [ -z "$output" ]


### PR DESCRIPTION
Closes #42, #43 and #44.

ADR 003 lands first because it decides what the three commits after it are
allowed to write. Its effect on #42 is large: four of the five principles that
issue proposed for CLAUDE.md belong somewhere else, and two are already carried
today by `docs/planning/templates/scope.md` and `global-claude/skills/design/SKILL.md`.
So #42 ships as the measurement work it always also contained, and its digest
half becomes two citations and one follow-up issue.

#44 arrives amended: Case C is a third tier rather than confirming always,
because its design document was approved before any code was written.

D-6 and D-7 were both observed failing before being trusted, with the boundary
checked at 200 and 201 lines. They give a mechanism to "Global layer size
discipline", which `docs/designs/global-layer-injection.md` §5.2 has named as a
Denial of Service control since it was written without anything ever enforcing it.

The SDD gap found while writing them is #51.
