### PR TITLE
fix(skills): make the design skill's description load

### DIFF
--- a/global-claude/skills/design/SKILL.md
+++ b/global-claude/skills/design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design
-description:
-> Invoke at the beginning of any significant change — new feature, major refactor, architectural decision, or multi-file modification. Also invoke explicitly to initialize the docs-as-code workflow for a new project. Classifies the change, selects the appropriate workflow, and guides artifact production before any code is written.
+description: >
+  Invoke at the beginning of any significant change — new feature, major refactor, architectural decision, or multi-file modification. Also invoke explicitly to initialize the docs-as-code workflow for a new project. Classifies the change, selects the appropriate workflow, and guides artifact production before any code is written.
 ---
 
 <!-- template-version: docs-as-code-workflow-template 1.0.0 -->


### PR DESCRIPTION
Closes #56.

`description:` had an empty value with the `>` indicator at column 0 on the next
line, so it was not a block scalar. The description resolved to the body's first
non-blank line — the `template-version` comment — and the trigger never reached
context.

A skill's description is the half that is always loaded, so this left
`global-claude/CLAUDE.md`'s Design Workflow rule depending on a trigger that was
not firing. Nothing in the suite could see it: D-2 checks that named skills are
committed, D-4 that directories carry a manifest, and neither parses frontmatter.

Verified both directions — before the change the description resolved to the
comment, after it resolves to the trigger text — and all eight skills now yield
real trigger text. Confirming it actually loads needs a session restart, since
the global layer is copied into `~/.claude` at container start.

Whether a check should assert that every SKILL.md frontmatter parses is left to
#55 or its own issue; this is the instance, not the generalisation.
