### PR TITLE
fix(entrypoint): detect a drifted commit-msg hook instead of skipping

### DIFF
--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -111,17 +111,38 @@ echo "[entrypoint] Checking /workspace for commit-msg hook"
 
 HOOK_DIR="/workspace/.git/hooks"
 HOOK_PATH="${HOOK_DIR}/commit-msg"
+HOOK_SRC="${HOME}/.claude/hooks/commit-msg"
 
+# Installing only when absent meant a hook change reached repositories that
+# had never had one and nowhere else. Every project already using it kept
+# whatever version it was given, with no signal that a later fix existed —
+# rung 2 for a mechanism that is otherwise rung 5.
+#
+# This compares contents rather than a version marker: there is nothing to
+# remember to bump, and a marker that was not bumped is indistinguishable
+# from a hook that is current. It deliberately does not judge what the
+# difference means. A drifted hook may be stale or may be a local
+# customisation, and telling those apart requires running it, which is what
+# the commit-hook-setup skill's probes do.
 if [ ! -d "/workspace/.git" ]; then
     echo "[entrypoint] No .git directory found — commit-msg hook installation skipped"
-elif [ -f "$HOOK_PATH" ]; then
-    echo "[entrypoint] commit-msg hook already present at $HOOK_PATH — skipping"
-    echo "[entrypoint] Invoke the commit-hook-setup skill to inspect or update it"
-else
+elif [ ! -f "$HOOK_SRC" ]; then
+    echo "[entrypoint] WARNING: no commit-msg hook in the global layer"
+    echo "[entrypoint]   expected at $HOOK_SRC"
+    echo "[entrypoint]   Nothing to install or compare against; commits are unchecked."
+elif [ ! -f "$HOOK_PATH" ]; then
     mkdir -p "$HOOK_DIR"
-    cp "${HOME}/.claude/hooks/commit-msg" "$HOOK_PATH"
+    cp "$HOOK_SRC" "$HOOK_PATH"
     chmod +x "$HOOK_PATH"
     echo "[entrypoint] commit-msg hook installed at $HOOK_PATH"
+elif cmp -s "$HOOK_PATH" "$HOOK_SRC"; then
+    echo "[entrypoint] OK: commit-msg hook matches the shipped version"
+else
+    echo "[entrypoint] WARNING: installed commit-msg hook differs from the shipped one"
+    echo "[entrypoint]   $HOOK_PATH"
+    echo "[entrypoint]   It may predate a fix, or be a deliberate local customisation."
+    echo "[entrypoint]   Reading it will not tell you which — only running it will."
+    echo "[entrypoint]   Fix: invoke the commit-hook-setup skill to probe what it enforces"
 fi
 
 echo "[entrypoint] Commit-msg hook check complete"

--- a/docs/claude_code_security_plan.md
+++ b/docs/claude_code_security_plan.md
@@ -1125,3 +1125,57 @@ mount-construction mechanism per engine (e.g. switching Docker to the legacy `-v
 
 No other STRIDE category in §5 changes as a result of this work. The Docker-path
 residual noted above remains open.
+
+---
+
+### Change 20 — Commit-msg Hook Drift Detection at Session Start
+**Affects:** `base/entrypoint.sh`, `global-claude/skills/commit-hook-setup/SKILL.md`. Date: 2026-09-02.
+
+**What changed:**
+The commit-msg hook branch in `base/entrypoint.sh` no longer skips whenever a hook
+is already present. It now compares the installed `/workspace/.git/hooks/commit-msg`
+against the shipped copy in `~/.claude/hooks/` and logs one of three outcomes: `OK`
+when they match, a `WARNING` block when they differ, or an install when none exists.
+The check remains warn-only — a difference is never resolved automatically, and the
+existing hook is never replaced or deleted.
+
+A missing-source branch was added alongside it. The previous `cp` was unguarded, so
+with the global layer absent — a state the entrypoint warns about and continues past
+during injection — `set -euo pipefail` aborted the script before `exec "$@"` and the
+container failed to start. That path now warns and continues.
+
+Content comparison was chosen over a version marker in the hook. A marker has to be
+remembered on every edit, and one that was not bumped is indistinguishable from a
+hook that is current — the failure mode this change exists to close, reintroduced one
+level up. The entrypoint deliberately does not classify what a difference means:
+distinguishing a stale hook from a deliberate local customisation requires running it,
+which is what the probes in the commit-hook-setup skill do.
+
+**Why:** the hook shipped in the global layer was widened to reject tool-generated
+attribution as a class rather than one literal trailer (issue #45). Because the
+entrypoint installed only into repositories that had never had a hook, that fix
+reached none of the repositories already using one, and no signal existed that a
+copy was stale. This repository was itself an instance: its installed hook predated
+the change, accepted a `Generated with ...` footer, and nothing detected it.
+
+**STRIDE mapping (delta only):**
+
+| Threat (STRIDE) | Control added |
+|---|---|
+| **Repudiation (R)** | Divergence between the shipped and installed commit-msg hook is surfaced as a logged event at a deterministic point on every session start, at the same place as the global-layer merge log. Converts an indefinitely silent state into a one-line record. |
+| **Denial of Service (D)** | The unguarded `cp` on the install path could abort the entrypoint before `exec "$@"` when the global layer was absent, preventing container start. Guarded; the entrypoint's warn-only contract now holds across every branch of this check. |
+
+No other STRIDE category is affected. The check reads two files and writes nothing;
+it introduces no new mount, no new privilege, and no new network surface.
+
+**Residual, not yet closed:**
+- The entrypoint detects *difference*, not *correctness*. A hook identical to the
+  shipped one is reported `OK` regardless of what that shipped hook enforces.
+- An operator with a deliberately customised hook is warned on every session start.
+  A warning that is expected is a warning that gets ignored, which degrades the
+  control for exactly the users who understood it.
+- Both the entrypoint and the setup skill assume hooks live at `.git/hooks/`. Git's
+  `core.hooksPath` redirects them elsewhere, in which case the file being compared
+  is not the file git runs. Unset in this repository; undetected if set.
+- `git commit --no-verify` bypasses the hook entirely. This control governs the
+  hook's contents, never its invocation.

--- a/tests/test_global_layer.bats
+++ b/tests/test_global_layer.bats
@@ -108,3 +108,78 @@ teardown() {
     run grep -q '"Write(/run/\*)"' "${SANDBOX_DIR}/settings.json"
     [ "$status" -eq 0 ]
 }
+
+# Entrypoint commit-msg hook checks (issue #54).
+#
+# These are the first tests in the suite to assert on entrypoint stdout —
+# G-1 here, B-1 in test_build.bats and R-1 in test_runtime_posture.bats all
+# filter those lines out because they are noise for what those tests assert.
+# Here the log line is the assertion: the entrypoint's only output for a
+# drifted hook is what it prints.
+#
+# Tagged `fast` and not `hostonly`: this file's setup() requires a reachable
+# engine and a built claude-base, so CI (--filter-tags hostonly) does not run
+# them. The documented pre-merge gate `bats tests/` is what exercises these.
+
+# bats test_tags=fast
+@test "G-7: a commit-msg hook differing from the shipped one is reported as drift" {
+    register_container "$CONTAINER_NAME"
+
+    G7_TMPDIR="$(mktemp -d)"
+    mkdir -p "${G7_TMPDIR}/.git/hooks"
+    printf '#!/usr/bin/env bash\n# a hook predating the trailer widening\nexit 0\n' \
+        > "${G7_TMPDIR}/.git/hooks/commit-msg"
+    chmod +x "${G7_TMPDIR}/.git/hooks/commit-msg"
+
+    relabel_arg=""
+    userns_args=()
+    if [ "$ENGINE" = "podman" ]; then
+        relabel_arg=",relabel=shared"
+        userns_args=(--userns=keep-id:uid=1000,gid=1000)
+    fi
+
+    run engine_run --rm --name "$CONTAINER_NAME" \
+        --mount "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly${relabel_arg}" \
+        --mount "type=bind,source=${G7_TMPDIR},target=/workspace${relabel_arg}" \
+        "${userns_args[@]}" \
+        claude-base true
+
+    # Container must still start: the check is warn-only, never fatal.
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARNING: installed commit-msg hook differs from the shipped one"* ]]
+
+    # And the drifted hook must be left exactly as it was — the entrypoint
+    # reports, it does not resolve.
+    [ "$(sed -n '2p' "${G7_TMPDIR}/.git/hooks/commit-msg")" = "# a hook predating the trailer widening" ]
+
+    rm -rf "$G7_TMPDIR"
+}
+
+# bats test_tags=fast
+@test "G-8: a commit-msg hook matching the shipped one is reported as current" {
+    register_container "$CONTAINER_NAME"
+
+    G8_TMPDIR="$(mktemp -d)"
+    mkdir -p "${G8_TMPDIR}/.git/hooks"
+    cp "${GLOBAL_BASE}/hooks/commit-msg" "${G8_TMPDIR}/.git/hooks/commit-msg"
+    chmod +x "${G8_TMPDIR}/.git/hooks/commit-msg"
+
+    relabel_arg=""
+    userns_args=()
+    if [ "$ENGINE" = "podman" ]; then
+        relabel_arg=",relabel=shared"
+        userns_args=(--userns=keep-id:uid=1000,gid=1000)
+    fi
+
+    run engine_run --rm --name "$CONTAINER_NAME" \
+        --mount "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly${relabel_arg}" \
+        --mount "type=bind,source=${G8_TMPDIR},target=/workspace${relabel_arg}" \
+        "${userns_args[@]}" \
+        claude-base true
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK: commit-msg hook matches the shipped version"* ]]
+    [[ "$output" != *"WARNING: installed commit-msg hook differs"* ]]
+
+    rm -rf "$G8_TMPDIR"
+}


### PR DESCRIPTION
Closes #54.

The entrypoint installed a hook only into repositories that had never had one, so
the widened trailer pattern from #45 reached none of the repositories already
using it — this one included. It now compares the installed hook against the
shipped copy and reports drift.

Contents rather than a version marker: a marker has to be remembered on every
edit, and one that was not bumped is indistinguishable from a hook that is
current — the same failure one level up. The entrypoint deliberately does not
judge what a difference *means*; a drifted hook may be stale or a deliberate
customisation, and telling those apart requires running it, which is what the
`commit-hook-setup` probes do.

**Beyond the issue:** the install path's `cp` was unguarded. With the global
layer absent — a state the entrypoint warns about and continues past — `set -e`
aborted before `exec "$@"` and the container never started. Pre-existing on
`main`, observed at exit 1 while testing this, and fixed here because it
contradicts the warn-only contract Change 20 documents.

Change 20 records both moved STRIDE categories and four residual gaps, including
that `core.hooksPath` would point git at a file neither the entrypoint nor the
skill compares.

**G-7 and G-8 have not been executed.** No container engine exists in the sandbox
image. All five entrypoint branches were exercised directly against the extracted
source, and every asserted substring was checked to appear verbatim in
`base/entrypoint.sh`, but the tests themselves are unobserved — they are tagged
`fast`, so CI will not run them either. `./build.sh base && bats tests/test_global_layer.bats`
on a host with an engine is needed before trusting them.
