### PR TITLE
fix(entrypoint): resolve the hooks directory instead of assuming it

### DIFF
--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -109,9 +109,29 @@ echo "[entrypoint] Node.js addon check complete"
 
 echo "[entrypoint] Checking /workspace for commit-msg hook"
 
-HOOK_DIR="/workspace/.git/hooks"
-HOOK_PATH="${HOOK_DIR}/commit-msg"
 HOOK_SRC="${HOME}/.claude/hooks/commit-msg"
+
+# Resolve the hooks directory git will actually use, rather than assuming
+# /workspace/.git/hooks. That literal missed two shapes, both silently:
+#
+#   - core.hooksPath redirects hooks elsewhere, so the file inspected here
+#     is not the file git runs — the check reports on the wrong artifact
+#     while looking healthy.
+#   - In a linked worktree or a submodule, .git is a FILE holding a
+#     "gitdir:" pointer, not a directory. A [ -d ] test therefore concluded
+#     "not a repository" and skipped the entire check, telling the operator
+#     there was no git repo while they stood in one.
+#
+# rev-parse --git-path resolves all three shapes. It returns a relative path
+# in the default case and an absolute one when redirected, so it has to be
+# resolved against /workspace rather than used raw.
+HOOK_DIR="$(cd /workspace 2>/dev/null && git rev-parse --git-path hooks 2>/dev/null)" || HOOK_DIR=""
+case "$HOOK_DIR" in
+    "") ;;
+    /*) ;;
+    *)  HOOK_DIR="/workspace/${HOOK_DIR}" ;;
+esac
+HOOK_PATH="${HOOK_DIR}/commit-msg"
 
 # Installing only when absent meant a hook change reached repositories that
 # had never had one and nowhere else. Every project already using it kept
@@ -124,8 +144,8 @@ HOOK_SRC="${HOME}/.claude/hooks/commit-msg"
 # difference means. A drifted hook may be stale or may be a local
 # customisation, and telling those apart requires running it, which is what
 # the commit-hook-setup skill's probes do.
-if [ ! -d "/workspace/.git" ]; then
-    echo "[entrypoint] No .git directory found — commit-msg hook installation skipped"
+if [ -z "$HOOK_DIR" ]; then
+    echo "[entrypoint] /workspace is not a git repository — commit-msg hook installation skipped"
 elif [ ! -f "$HOOK_SRC" ]; then
     echo "[entrypoint] WARNING: no commit-msg hook in the global layer"
     echo "[entrypoint]   expected at $HOOK_SRC"
@@ -137,6 +157,8 @@ elif [ ! -f "$HOOK_PATH" ]; then
     echo "[entrypoint] commit-msg hook installed at $HOOK_PATH"
 elif cmp -s "$HOOK_PATH" "$HOOK_SRC"; then
     echo "[entrypoint] OK: commit-msg hook matches the shipped version"
+    [ "$HOOK_DIR" = "/workspace/.git/hooks" ] \
+        || echo "[entrypoint]   (hooks directory is $HOOK_DIR, not the default)"
 else
     echo "[entrypoint] WARNING: installed commit-msg hook differs from the shipped one"
     echo "[entrypoint]   $HOOK_PATH"

--- a/docs/claude_code_security_plan.md
+++ b/docs/claude_code_security_plan.md
@@ -1176,6 +1176,53 @@ it introduces no new mount, no new privilege, and no new network surface.
   control for exactly the users who understood it.
 - Both the entrypoint and the setup skill assume hooks live at `.git/hooks/`. Git's
   `core.hooksPath` redirects them elsewhere, in which case the file being compared
-  is not the file git runs. Unset in this repository; undetected if set.
+  is not the file git runs. Unset in this repository; undetected if set. Closed by Change 21.
 - `git commit --no-verify` bypasses the hook entirely. This control governs the
   hook's contents, never its invocation.
+
+---
+
+### Change 21 — Hooks Directory Resolved Instead of Assumed
+**Affects:** `base/entrypoint.sh`, `global-claude/skills/commit-hook-setup/SKILL.md`. Date: 2026-09-02.
+
+**What changed:**
+Both the entrypoint check added in Change 20 and the setup skill's probes hardcoded
+`/workspace/.git/hooks`. They now resolve the directory git will actually use, via
+`git rev-parse --git-path hooks`, and fall back to reporting "not a git repository"
+only when that resolution fails. The entrypoint additionally logs the resolved path
+whenever it is not the default, so an operator who redirected hooks can see which
+file was inspected.
+
+**Why:** the hardcoded path missed two shapes, both silently, and the first was
+worse than a miss.
+
+With `core.hooksPath` set, the previous code installed a hook at
+`.git/hooks/commit-msg` — a file git never executes — and reported success, while
+the hook git does run was left unexamined. That is not a gap in coverage but a
+false assurance: the log said the control was in place.
+
+In a linked worktree or submodule, `.git` is a file holding a `gitdir:` pointer
+rather than a directory. The `[ -d /workspace/.git ]` test therefore concluded
+there was no repository and skipped the entire check, printing "No .git directory
+found" at an operator standing in one. This required no misconfiguration; any
+operator running the sandbox against a worktree got unenforced commits and a
+message explaining why that was expected.
+
+Both were verified against the previous implementation before the change and
+against the new one after.
+
+**STRIDE mapping (delta only):**
+
+| Threat (STRIDE) | Control added |
+|---|---|
+| **Repudiation (R)** | The drift check introduced in Change 20 now inspects the file git executes rather than a path assumed to be it, so its `OK` and `WARNING` records describe the enforcing artifact. Previously an `OK` could refer to a file with no bearing on any commit. |
+| **Tampering (T)** | Partially offsetting, and recorded rather than glossed: the install path now writes to a directory derived from repository configuration instead of a fixed literal. A repository whose `core.hooksPath` points outside itself will have the hook installed there. Bounded by the container's existing posture — non-root, `--cap-drop=ALL`, no writes outside what `claude-agent` can reach — and by the operator having chosen to mount that repository. |
+
+No other STRIDE category is affected.
+
+**Residual, not yet closed:**
+- `git commit --no-verify` still bypasses hooks entirely, whatever path they live
+  at. This governs which file is inspected, never whether git consults it.
+- The two remaining residuals from Change 20 stand: the check compares contents
+  and cannot judge correctness, and an operator with a deliberately customised
+  hook is warned every session.

--- a/global-claude/skills/commit-hook-setup/SKILL.md
+++ b/global-claude/skills/commit-hook-setup/SKILL.md
@@ -15,11 +15,22 @@ description: >
 - First session on a new repository where an existing hook was found
 - Operator asks to install, verify, or update the commit-msg hook
 
-## Step 1 — Inspect
+## Step 1 — Find the hooks directory, then inspect
+
+Do not assume `.git/hooks`. `core.hooksPath` redirects hooks elsewhere, and in
+a linked worktree or submodule `.git` is a file holding a pointer rather than a
+directory. Inspecting the wrong path reports confidently on a file git never
+runs.
 
 ```bash
-cat /workspace/.git/hooks/commit-msg 2>/dev/null || echo "(no hook present)"
+HOOKS="$(cd /workspace && git rev-parse --git-path hooks)"
+case "$HOOKS" in /*) ;; *) HOOKS="/workspace/$HOOKS" ;; esac
+echo "hooks directory: $HOOKS"
+cat "$HOOKS/commit-msg" 2>/dev/null || echo "(no hook present)"
 ```
+
+Report the resolved path whenever it is not `/workspace/.git/hooks` — an
+operator who redirected hooks needs to see which file was examined.
 
 ## Step 2 — Decide
 
@@ -36,7 +47,7 @@ indistinguishable by eye. Run Step 2a and decide on what it does.
 ```bash
 probe() {
     printf 'test: probe\n\n%s\n' "$2" > /tmp/hook-probe
-    if bash /workspace/.git/hooks/commit-msg /tmp/hook-probe > /dev/null 2>&1; then
+    if bash "$HOOKS/commit-msg" /tmp/hook-probe > /dev/null 2>&1; then
         [ "$1" = accept ] && echo "ok:   accepted — $2" || echo "GAP: accepted — $2"
     else
         [ "$1" = reject ] && echo "ok:   rejected — $2" || echo "OVER-BROAD: rejected — $2"
@@ -69,9 +80,12 @@ Never overwrite silently.
 ## Step 3 — Install standard hook
 
 ```bash
-cp ~/.claude/hooks/commit-msg /workspace/.git/hooks/commit-msg
-chmod +x /workspace/.git/hooks/commit-msg
+cp ~/.claude/hooks/commit-msg "$HOOKS/commit-msg"
+chmod +x "$HOOKS/commit-msg"
 ```
+
+`$HOOKS` is the path resolved in Step 1. Re-resolve it if this step runs in a
+new shell.
 
 Verify by re-running Step 2a. `ls -la` and `cat` confirm the file arrived;
 only the probes confirm it enforces anything.

--- a/tests/test_global_layer.bats
+++ b/tests/test_global_layer.bats
@@ -126,7 +126,7 @@ teardown() {
     register_container "$CONTAINER_NAME"
 
     G7_TMPDIR="$(mktemp -d)"
-    mkdir -p "${G7_TMPDIR}/.git/hooks"
+    git init -q "$G7_TMPDIR"
     printf '#!/usr/bin/env bash\n# a hook predating the trailer widening\nexit 0\n' \
         > "${G7_TMPDIR}/.git/hooks/commit-msg"
     chmod +x "${G7_TMPDIR}/.git/hooks/commit-msg"
@@ -160,7 +160,7 @@ teardown() {
     register_container "$CONTAINER_NAME"
 
     G8_TMPDIR="$(mktemp -d)"
-    mkdir -p "${G8_TMPDIR}/.git/hooks"
+    git init -q "$G8_TMPDIR"
     cp "${GLOBAL_BASE}/hooks/commit-msg" "${G8_TMPDIR}/.git/hooks/commit-msg"
     chmod +x "${G8_TMPDIR}/.git/hooks/commit-msg"
 
@@ -183,3 +183,48 @@ teardown() {
 
     rm -rf "$G8_TMPDIR"
 }
+
+# bats test_tags=fast
+@test "G-9: the hook check follows core.hooksPath rather than assuming .git/hooks" {
+    register_container "$CONTAINER_NAME"
+
+    G9_TMPDIR="$(mktemp -d)"
+    git init -q "$G9_TMPDIR"
+    mkdir -p "${G9_TMPDIR}/.githooks"
+    git -C "$G9_TMPDIR" config core.hooksPath .githooks
+    printf '#!/usr/bin/env bash\n# stale hook in a redirected directory\nexit 0\n' \
+        > "${G9_TMPDIR}/.githooks/commit-msg"
+    chmod +x "${G9_TMPDIR}/.githooks/commit-msg"
+
+    relabel_arg=""
+    userns_args=()
+    if [ "$ENGINE" = "podman" ]; then
+        relabel_arg=",relabel=shared"
+        userns_args=(--userns=keep-id:uid=1000,gid=1000)
+    fi
+
+    run engine_run --rm --name "$CONTAINER_NAME" \
+        --mount "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly${relabel_arg}" \
+        --mount "type=bind,source=${G9_TMPDIR},target=/workspace${relabel_arg}" \
+        "${userns_args[@]}" \
+        claude-base true
+
+    [ "$status" -eq 0 ]
+    # The redirected hook is the one reported on, by its resolved path.
+    [[ "$output" == *"WARNING: installed commit-msg hook differs from the shipped one"* ]]
+    [[ "$output" == *"/workspace/.githooks/commit-msg"* ]]
+
+    # And nothing was written to the directory git does not consult. Before the
+    # hooks path was resolved, the entrypoint installed a decoy here and
+    # reported success while the hook above went unexamined.
+    [ ! -e "${G9_TMPDIR}/.git/hooks/commit-msg" ]
+
+    rm -rf "$G9_TMPDIR"
+}
+
+# The linked-worktree shape is deliberately not covered here. A worktree's .git
+# file holds an absolute gitdir: pointer into the main repository, so testing it
+# in-container would need both trees bind-mounted at host-identical paths — more
+# fixture machinery than the assertion is worth. It is verified against the
+# extracted entrypoint block on the host instead, and recorded in
+# docs/claude_code_security_plan.md Change 21.


### PR DESCRIPTION
Closes #61.

`base/entrypoint.sh` and the setup skill both hardcoded `/workspace/.git/hooks`.
They now resolve the directory git will actually use, with
`git rev-parse --git-path hooks` — already available, git 2.39.5 is in the base
image.

**The `core.hooksPath` case was worse than a miss.** Verified against `main`:
with hooks redirected, the old code installed a hook at `.git/hooks/commit-msg`,
a file git never executes, and logged success — while the hook git does run sat
unexamined. Not a coverage gap but a false assurance, in the check #54 added to
close a false assurance.

**The worktree case needed no misconfiguration.** In a linked worktree `.git` is
a file holding a `gitdir:` pointer, so `[ -d /workspace/.git ]` was false and the
entire check skipped, printing "No .git directory found" at an operator standing
in a repository. Also verified against `main`.

All six shapes — not a repo, no hook, identical, drifted, redirected, worktree —
were exercised against the extracted entrypoint block, before and after.

**G-7 and G-8 would have broken.** Their fixtures used `mkdir -p .git/hooks` with
no `git init`; the old `[ -d ]` test accepted that and `rev-parse` correctly does
not. Found by re-running each fixture against the changed code rather than
assuming they still held. Both now `git init`, and G-9 covers the redirected
case including that no decoy is written to the unused directory.

Change 21 is **appended, not an amendment to Change 20**, which was accurate when
written — a chronological record that gets retroactively edited stops being one.
Change 20 gains a cross-reference. The Tampering row is recorded rather than
glossed: the install path now writes to a directory derived from repository
config instead of a fixed literal.

**G-7, G-8 and G-9 are unexecuted here** — no container engine in the sandbox
image, and they are tagged `fast`, so CI will not run them either. Each fixture
was simulated against the extracted entrypoint block and produces exactly what
the test asserts. `./build.sh base && bats tests/test_global_layer.bats` on a
host with an engine is still what confirms them.
