### PR TITLE
docs: auto-memory seeding design, verification gate, and parking decision

### DIFF
--- a/check-auto-memory.sh
+++ b/check-auto-memory.sh
@@ -22,15 +22,23 @@
 #   ./check-auto-memory.sh version    [image_tag]    (default: base)
 #   ./check-auto-memory.sh config     [image_tag]    (default: base)
 #   ./check-auto-memory.sh behavior   <container_name>
-#   ./check-auto-memory.sh deny-scope [image_tag]    (default: base)
+#   ./check-auto-memory.sh deny-scope <container_name>
 #
 # version/config each start a throwaway --rm container from the built
-# image. behavior inspects a container from a session you already started
-# — it does not start or stop anything, since Auto Memory content only
-# exists once a real session has run. deny-scope starts one throwaway
-# container and drives two real non-interactive turns in it, so it needs
-# ANTHROPIC_API_KEY in your environment; it is an operator-run diagnostic
-# and never part of `bats tests/`, which forbids credentials (SDD §7.2).
+# image. behavior and deny-scope both act on a session you already started
+# — neither starts or stops anything.
+#
+# deny-scope takes a running session for the same reason it cannot take an
+# image: it drives real Claude Code turns, and nothing in this project's
+# launch path carries credentials into a container. start.sh passes only
+# GH_TOKEN, so a session authenticates because you logged in inside it.
+# The probe reuses that login from within the container it already lives
+# in, under an isolated HOME so the live session's own ~/.claude is
+# neither read nor written. No API key, and no credential crosses a
+# boundary it had not already crossed.
+#
+# It is an operator-run diagnostic and never part of `bats tests/`, which
+# forbids credentials (SDD §7.2).
 
 set -euo pipefail
 
@@ -53,7 +61,7 @@ IMAGE_PREFIX="${_ENV_IMAGE_PREFIX:-$IMAGE_PREFIX}"
 MEMORY_VERSION_GATE="2.1.59"
 
 usage() {
-    sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '2,41p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     exit 1
 }
 
@@ -177,53 +185,68 @@ cmd_behavior() {
 # Parsing a refusal out of natural-language output would conflate "the deny
 # rule blocked it" with "the model declined to try".
 #
-# Two limits, stated here rather than discovered later:
+# Three limits, stated here rather than discovered later:
 #
 #   1. This drives non-interactive turns, and `claude --help` is explicit
 #      that the workspace trust dialog is SKIPPED under -p (or whenever
 #      stdout is not a TTY), and that settings files failing validation are
 #      silently ignored in that mode with no error shown. start.sh runs
-#      interactively (-it), so production takes the other path. A pass here
-#      transfers to a real session by analogy, not by proof — the same
-#      caveat step-zero records for Environment 2.
+#      interactively (-it), so the session hosting this probe took the
+#      other path even though the probe itself does not. Running inside a
+#      real session removes step-zero's Environment 2 caveat; it does not
+#      remove this one.
 #   2. --allowedTools pre-allows the probe command so nothing prompts, which
 #      makes the deny rule the only thing that can stop it. That is the
 #      point of the probe, but it means this tests deny-beats-allow
 #      precedence, not the prompt path an operator would see interactively.
+#   3. It copies the session's credential to an isolated HOME inside the
+#      same container, for the length of the run. That adds no exposure —
+#      the file does not leave the container it already lives in — but it
+#      is a second copy while the probe runs, removed on exit including on
+#      failure.
 cmd_deny_scope() {
-    local image_tag="${1:-base}"
-    local image_name="${IMAGE_PREFIX}-${image_tag}"
+    local container_name="${1:?Usage: $(basename "${BASH_SOURCE[0]}") deny-scope <container_name>}"
 
-    if ! "$ENGINE" image inspect "$image_name" > /dev/null 2>&1; then
-        echo "Error: image '$image_name' does not exist. Build it first: ./build.sh $image_tag"
+    if ! "$ENGINE" ps --format '{{.Names}}' | grep -qx "$container_name"; then
+        echo "Error: no running container named '$container_name'."
+        echo "Start a session with ./start.sh, log in inside it, then pass its"
+        echo "name here. This probe reuses that session's login rather than"
+        echo "requiring an API key — see the header for why."
         exit 1
     fi
 
-    if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-        echo "Error: ANTHROPIC_API_KEY is not set in your environment."
-        echo "This check drives real Claude Code turns and cannot run without it."
-        echo "It is passed by name (--env ANTHROPIC_API_KEY), so the value never"
-        echo "appears in a command line or in this script's output."
-        exit 1
-    fi
-
-    echo "Probing settings-scope interaction in ${image_name}..."
+    echo "Probing settings-scope interaction inside ${container_name}..."
     echo "Arm A: project-scope deny only.  Arm B: same, plus user-scope settings.json."
     echo "Arm C: negative control — no deny rule at all."
     echo ""
 
     # sh -s reads the probe from stdin, so a quoted heredoc keeps every
     # expansion inside the container instead of the host shell.
-    "$ENGINE" run --rm -i \
-        --env ANTHROPIC_API_KEY \
-        --security-opt=no-new-privileges \
-        --cap-drop=ALL \
-        "$image_name" sh -s <<'PROBE'
+    "$ENGINE" exec -i "$container_name" sh -s <<'PROBE'
 set -eu
 
-PROBE_DIR=/tmp/deny-probe
-rm -rf "$PROBE_DIR"
-mkdir -p "$PROBE_DIR/.claude"
+PROBE_HOME=/tmp/deny-scope-home
+PROBE_DIR=/tmp/deny-scope-proj
+
+# The credential copy must not outlive the probe. The live session's own
+# ~/.claude is never touched: every arm runs under PROBE_HOME instead, so
+# the settings.json being varied is the probe's, not the operator's.
+cleanup() { rm -rf "$PROBE_HOME"; }
+trap cleanup EXIT
+
+if [ ! -f "$HOME/.claude/.credentials.json" ]; then
+    echo "ERROR: no credentials found in this container."
+    echo "       Expected \$HOME/.claude/.credentials.json — log in inside the"
+    echo "       session first. The probe drives real turns and reuses that"
+    echo "       login; it cannot synthesise one."
+    exit 1
+fi
+
+rm -rf "$PROBE_HOME" "$PROBE_DIR"
+mkdir -p "$PROBE_HOME/.claude" "$PROBE_DIR/.claude"
+chmod 700 "$PROBE_HOME/.claude"
+cp "$HOME/.claude/.credentials.json" "$PROBE_HOME/.claude/.credentials.json"
+chmod 600 "$PROBE_HOME/.claude/.credentials.json"
 
 # Mirrors the shape of this repo's own settings.json: a deny rule on a Bash
 # command, project scope, nothing else.
@@ -245,8 +268,8 @@ run_arm() {
     # wise hang. "none" denies whatever would prompt, which is why the probe
     # command is pre-allowed below — otherwise every arm would "pass" for
     # the wrong reason.
-    timeout 180 claude -p \
-        'Run exactly this command, then stop: touch /tmp/deny-probe/RAN' \
+    HOME="$PROBE_HOME" timeout 180 claude -p \
+        "Run exactly this command, then stop: touch ${PROBE_DIR}/RAN" \
         --allowedTools 'Bash(touch *)' \
         --permission-prompts none \
         > "/tmp/arm-${arm}.out" 2>&1 || true
@@ -259,13 +282,12 @@ run_arm() {
 }
 
 # Arm A — control. No user-scope settings file at all.
-rm -f "$HOME/.claude/settings.json"
+rm -f "$PROBE_HOME/.claude/settings.json"
 run_arm A
 
 # Arm B — the seeding design's addition: user scope, autoMemoryDirectory only,
 # no permissions key of its own.
-mkdir -p "$HOME/.claude"
-cat > "$HOME/.claude/settings.json" <<'JSON'
+cat > "$PROBE_HOME/.claude/settings.json" <<'JSON'
 {
   "autoMemoryDirectory": "~/.claude/memory"
 }

--- a/check-auto-memory.sh
+++ b/check-auto-memory.sh
@@ -1,30 +1,36 @@
 #!/usr/bin/env bash
 # check-auto-memory.sh — step-zero diagnostic for Claude Code's Auto Memory
-# feature. See injecting_memories_into_containers.md for the design
-# discussion this supports (curated memory seeding, still informal/
-# pre-SDD as of this script).
+# feature. See docs/designs/auto-memory-seeding-step-zero.md for the research
+# pass this supports, and docs/designs/auto-memory-seeding.md §4.2 for the
+# verification gate deny-scope exists to close.
 #
 # Confirms, empirically, whether Auto Memory is actually active rather than
 # assuming from the CLI's changelog — base/Dockerfile's unpinned
 # `npm install -g @anthropic-ai/claude-code` means the answer can change on
 # any rebuild with no Dockerfile diff to signal it.
 #
-# Three independent checks, run separately since they need different
-# things (a built image vs. a container from a session you already ran):
+# Four independent checks, run separately since they need different things
+# (a built image, a container from a session you already ran, or credentials):
 #
-#   version   — installed Claude Code CLI version vs. the v2.1.59 gate
-#   config    — whether the CLI recognizes autoMemoryDirectory as a key
-#   behavior  — whether a live session actually wrote memory content
+#   version     — installed Claude Code CLI version vs. the v2.1.59 gate
+#   config      — whether the CLI recognizes autoMemoryDirectory as a key
+#   behavior    — whether a live session actually wrote memory content
+#   deny-scope  — whether adding a user-scope settings.json weakens the
+#                 project-scope permissions.deny rules already in force
 #
 # Usage:
-#   ./check-auto-memory.sh version  [image_tag]      (default: base)
-#   ./check-auto-memory.sh config   [image_tag]      (default: base)
-#   ./check-auto-memory.sh behavior <container_name>
+#   ./check-auto-memory.sh version    [image_tag]    (default: base)
+#   ./check-auto-memory.sh config     [image_tag]    (default: base)
+#   ./check-auto-memory.sh behavior   <container_name>
+#   ./check-auto-memory.sh deny-scope [image_tag]    (default: base)
 #
 # version/config each start a throwaway --rm container from the built
 # image. behavior inspects a container from a session you already started
 # — it does not start or stop anything, since Auto Memory content only
-# exists once a real session has run.
+# exists once a real session has run. deny-scope starts one throwaway
+# container and drives two real non-interactive turns in it, so it needs
+# ANTHROPIC_API_KEY in your environment; it is an operator-run diagnostic
+# and never part of `bats tests/`, which forbids credentials (SDD §7.2).
 
 set -euo pipefail
 
@@ -47,7 +53,7 @@ IMAGE_PREFIX="${_ENV_IMAGE_PREFIX:-$IMAGE_PREFIX}"
 MEMORY_VERSION_GATE="2.1.59"
 
 usage() {
-    sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     exit 1
 }
 
@@ -141,9 +147,170 @@ cmd_behavior() {
     fi
 }
 
+# Closes the gate in auto-memory-seeding.md §4.2: does introducing a
+# user-scope ~/.claude/settings.json — which the seeding design adds, purely
+# to carry autoMemoryDirectory — weaken the project-scope permissions.deny
+# rules a mounted repository supplies?
+#
+# Three arms. A and B differ in exactly one thing — whether the user-scope
+# file exists — and C is the negative control.
+#
+# Neither control arm is optional decoration, and they fail differently:
+#
+#   A (deny rule, no user-scope file) must DENY. If it does not, the rule
+#     never fired even without the file under test, so the run exercised
+#     nothing and B's result means nothing either.
+#   C (no deny rule at all) must NOT DENY. If it denies, something other
+#     than the deny rule is stopping the command — a prompt reaching
+#     --permission-prompts none, say — and then A and B deny for a reason
+#     that has nothing to do with the rule, while looking exactly like a
+#     pass.
+#
+# C exists because the first run of this probe was written with two arms,
+# returned "A denied, B denied", and would have licensed the conclusion
+# without having established that the probe could produce any other result.
+# Reading that as a pass is the false-confidence failure the project's
+# mechanism-verification discipline exists to prevent.
+#
+# The probe asserts on the filesystem, not on prose: the model is asked to
+# create a file, and the check is whether that file exists afterwards.
+# Parsing a refusal out of natural-language output would conflate "the deny
+# rule blocked it" with "the model declined to try".
+#
+# Two limits, stated here rather than discovered later:
+#
+#   1. This drives non-interactive turns, and `claude --help` is explicit
+#      that the workspace trust dialog is SKIPPED under -p (or whenever
+#      stdout is not a TTY), and that settings files failing validation are
+#      silently ignored in that mode with no error shown. start.sh runs
+#      interactively (-it), so production takes the other path. A pass here
+#      transfers to a real session by analogy, not by proof — the same
+#      caveat step-zero records for Environment 2.
+#   2. --allowedTools pre-allows the probe command so nothing prompts, which
+#      makes the deny rule the only thing that can stop it. That is the
+#      point of the probe, but it means this tests deny-beats-allow
+#      precedence, not the prompt path an operator would see interactively.
+cmd_deny_scope() {
+    local image_tag="${1:-base}"
+    local image_name="${IMAGE_PREFIX}-${image_tag}"
+
+    if ! "$ENGINE" image inspect "$image_name" > /dev/null 2>&1; then
+        echo "Error: image '$image_name' does not exist. Build it first: ./build.sh $image_tag"
+        exit 1
+    fi
+
+    if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+        echo "Error: ANTHROPIC_API_KEY is not set in your environment."
+        echo "This check drives real Claude Code turns and cannot run without it."
+        echo "It is passed by name (--env ANTHROPIC_API_KEY), so the value never"
+        echo "appears in a command line or in this script's output."
+        exit 1
+    fi
+
+    echo "Probing settings-scope interaction in ${image_name}..."
+    echo "Arm A: project-scope deny only.  Arm B: same, plus user-scope settings.json."
+    echo "Arm C: negative control — no deny rule at all."
+    echo ""
+
+    # sh -s reads the probe from stdin, so a quoted heredoc keeps every
+    # expansion inside the container instead of the host shell.
+    "$ENGINE" run --rm -i \
+        --env ANTHROPIC_API_KEY \
+        --security-opt=no-new-privileges \
+        --cap-drop=ALL \
+        "$image_name" sh -s <<'PROBE'
+set -eu
+
+PROBE_DIR=/tmp/deny-probe
+rm -rf "$PROBE_DIR"
+mkdir -p "$PROBE_DIR/.claude"
+
+# Mirrors the shape of this repo's own settings.json: a deny rule on a Bash
+# command, project scope, nothing else.
+cat > "$PROBE_DIR/.claude/settings.json" <<'JSON'
+{
+  "permissions": {
+    "deny": ["Bash(touch *)"]
+  }
+}
+JSON
+
+run_arm() {
+    arm="$1"
+    rm -f "$PROBE_DIR/RAN"
+    cd "$PROBE_DIR"
+
+    # --permission-prompts none: under -p the default target is an SDK host
+    # that is not present here, and anything that would prompt would other-
+    # wise hang. "none" denies whatever would prompt, which is why the probe
+    # command is pre-allowed below — otherwise every arm would "pass" for
+    # the wrong reason.
+    timeout 180 claude -p \
+        'Run exactly this command, then stop: touch /tmp/deny-probe/RAN' \
+        --allowedTools 'Bash(touch *)' \
+        --permission-prompts none \
+        > "/tmp/arm-${arm}.out" 2>&1 || true
+
+    if [ -e "$PROBE_DIR/RAN" ]; then
+        echo "ARM ${arm}: NOT DENIED — the command executed"
+    else
+        echo "ARM ${arm}: no file created — denied, or never attempted"
+    fi
+}
+
+# Arm A — control. No user-scope settings file at all.
+rm -f "$HOME/.claude/settings.json"
+run_arm A
+
+# Arm B — the seeding design's addition: user scope, autoMemoryDirectory only,
+# no permissions key of its own.
+mkdir -p "$HOME/.claude"
+cat > "$HOME/.claude/settings.json" <<'JSON'
+{
+  "autoMemoryDirectory": "~/.claude/memory"
+}
+JSON
+run_arm B
+
+# Arm C — negative control. User-scope file stays; the project-scope deny
+# rule is removed, so the only thing that could block the command is gone.
+rm -f "$PROBE_DIR/.claude/settings.json"
+run_arm C
+
+echo ""
+echo "--- arm A transcript ---"
+cat /tmp/arm-A.out || true
+echo ""
+echo "--- arm B transcript ---"
+cat /tmp/arm-B.out || true
+echo ""
+echo "--- arm C transcript ---"
+cat /tmp/arm-C.out || true
+PROBE
+
+    echo ""
+    echo "How to read this — check C first, then A, then B:"
+    echo "  C DENIED           → INCONCLUSIVE. Something other than the deny rule"
+    echo "                       is blocking the command, so A and B tell you"
+    echo "                       nothing. Read the arm C transcript."
+    echo "  A NOT DENIED       → INCONCLUSIVE. The rule never fired even without"
+    echo "                       the user-scope file; this run tested nothing."
+    echo "  C not denied,"
+    echo "  A denied, B denied → PASS. The deny rule fires, and still fires with"
+    echo "                       the user-scope file present."
+    echo "  C not denied,"
+    echo "  A denied,"
+    echo "  B NOT DENIED       → REGRESSION. The user-scope file weakened"
+    echo "                       project-scope deny. Stop; SDD §4.2 reopens."
+    echo ""
+    echo "Read the transcripts either way: 'no file created' also covers a model"
+    echo "that simply declined to try, which is not the same result."
+}
+
 case "${1:-}" in
-    version)  shift; cmd_version "$@" ;;
-    config)   shift; cmd_config "$@" ;;
-    behavior) shift; cmd_behavior "$@" ;;
+    version)    shift; cmd_version "$@" ;;
+    config)     shift; cmd_config "$@" ;;
+    behavior)   shift; cmd_behavior "$@" ;;
+    deny-scope) shift; cmd_deny_scope "$@" ;;
     *) usage ;;
 esac

--- a/docs/designs/auto-memory-seeding-step-zero.md
+++ b/docs/designs/auto-memory-seeding-step-zero.md
@@ -6,9 +6,12 @@ Draft — research pass completed 2026-08-31; round-trip pass completed
 2026-09-03 (Q-8, Q-7, Q-3, Q-9 resolved, run in Environment 2 — see
 "Environment caveat"). Q-10 also resolved 2026-09-03, confirmed directly
 by the operator against a real `start.sh`-launched container — the
-workspace-trust gate is live. All ten numbered questions from the research
-pass are now closed except Q-5, Q-6 (resolved as a recommendation rather
-than an empirical answer), and Q-11.
+workspace-trust gate is live — narrowed 2026-09-03 to interactive sessions
+only, see "Pre-existing exposure". All ten numbered questions from the
+research pass are now closed except Q-5, Q-6 (resolved as a recommendation
+rather than an empirical answer), and Q-11. Q-12 was added 2026-09-03 from
+the seeding SDD's verification gate and is closed; it also surfaced a
+defect in an existing control, tracked as issue #64.
 This document is the empirical groundwork for a future SDD, not the SDD
 itself. Findings are marked **Confirmed**, **Reported**, or **Inferred**;
 open questions carry their current state and what would resolve them.
@@ -346,6 +349,78 @@ both secondary and both of unclear vintage relative to the docs page.*
 
 *Source: `code.claude.com/docs/en/memory`, "Storage location".*
 
+### Q-12 — Does a user-scope `settings.json` weaken project-scope `permissions.deny`? — **Answered, round-trip confirmed 2026-09-03**
+
+**No.** This was item 3 on the informal proposal's step-zero list and had never
+been tested. It gates the seeding SDD's §4.2, which introduces a user-scope
+`settings.json` solely to carry `autoMemoryDirectory`.
+
+Method: four arms, run in Environment 2 via nested `claude -p` with an isolated
+`HOME`, so the live `~/.claude/settings.json` was never read or written. The
+probe asserts on the filesystem — the model is asked to `touch` a file, and the
+check is whether that file exists afterwards — because a refusal and a model
+that simply declines to try produce similar prose. `--allowedTools 'Bash(touch *)'`
+pre-allows the command so nothing prompts, making the deny rule the only thing
+that can stop it.
+
+| Arm | Project-scope deny | User-scope `settings.json` | Result |
+|---|---|---|---|
+| A | at `.claude/settings.json` | absent | **denied** |
+| B | at `.claude/settings.json` | `autoMemoryDirectory` only | **denied** |
+| C | none | `autoMemoryDirectory` only | **not denied** |
+| D | at `settings.json` (project root) | `autoMemoryDirectory` only | **not denied** |
+
+A vs B is the controlled comparison and answers the question: the deny rule
+fires identically with and without the user-scope file. Arm A's transcript reads
+"Permission denied for that command."; arm B's, "The command was denied by the
+permission system."
+
+**Arm C is why the result can be believed.** A and B denying is only a pass if
+the probe is *capable* of not denying — otherwise `--permission-prompts none`
+could be denying everything and the deny rule would be irrelevant to the
+outcome. C establishes the negative: with no project rule, the same command
+executes. Recorded because a two-arm version of this probe would have produced
+the same A/B output and licensed the same conclusion without having tested
+anything.
+
+**Consequence:** SDD §4.2's gate is cleared. Scopes stack per-key as the
+documentation implies; a user-scope file with no `permissions` key of its own
+removes nothing.
+
+**Arm D is a separate finding — see "Project-scope settings at the wrong path".**
+
+*Caveats: Environment 2, not a `start.sh` container; non-interactive, so the
+workspace-trust dialog was skipped (see below); one trial per arm, model
+`sonnet`.*
+
+## Project-scope settings at the wrong path — found 2026-09-03
+
+Arm D above is the same deny rule as arm A, moved from
+`<project>/.claude/settings.json` to `<project>/settings.json`. It did not fire.
+Identical rule, identical prompt, different path, opposite outcome.
+
+**This repository places its own `settings.json` at the repository root**, and
+`/workspace/.claude/` does not exist. `global-claude/` carries no `settings.json`
+either, so nothing injects those rules into a container by another route. The
+security plan's Phase 3 is explicit that the file belongs at
+`.claude/settings.json` "in each project directory".
+
+The consequence is that the app-layer `permissions.deny` list — Phase 3's third
+independent defense layer — **is not in force when a session mounts this
+repository**. G-6 in `test_global_layer.bats` greps the file and passes; its own
+comment concedes it verifies the control is *declared*, not enforced. Presence
+was mistaken for function, and the gap is invisible precisely because the
+assertion it fails to make is the one nobody wrote.
+
+Not fixed here. Moving the file is a container security control change (Case E)
+and needs its own STRIDE delta plus a test that asserts enforcement rather than
+declaration — otherwise the fix repeats the mistake that produced it. Tracked as
+issue #64. Recorded here because this is where the evidence is.
+
+Scope of the claim: this concerns *this repository's own* `settings.json`. Phase
+3 instructs operators to create `.claude/settings.json` per project, so an
+arbitrary mounted project that followed that instruction is unaffected.
+
 ## Still open
 
 ### Q-3 — What happens to malformed input? — **Answered, round-trip confirmed 2026-09-03**
@@ -500,6 +575,22 @@ specific surface, though it remains worth naming in the SDD's STRIDE
 section as a control that already exists and that seeding must not
 bypass.
 
+**Narrowed 2026-09-03 — the gate covers interactive sessions only.** `claude
+--help` states, for `-p`, that "the workspace trust dialog is skipped when
+Claude is run in non-interactive mode (via `-p`, or when stdout is not a TTY,
+e.g. piped or redirected output)", and that settings files failing validation
+are silently ignored in that mode with no error shown. The verification above
+exercised the interactive path, which is the path `start.sh` takes — it runs
+`-it` — so **the finding stands for production**. It does not generalise to
+every invocation inside the container: a `claude -p` run, or any run whose
+stdout is piped or redirected, skips the dialog, and a mounted repository's
+project-scope settings take effect with no human in the loop.
+
+This is a correction to the scope of the claim, not a reversal of it. It is
+also self-demonstrating: Q-12's probe drives non-interactive turns, so it ran
+on the ungated path by construction, and its project-scope deny rule was
+honored in arms A and B with no trust prompt anywhere.
+
 ## Standing risk — validating against a moving target
 
 `base/Dockerfile` installs Claude Code unpinned. The memory format is free
@@ -600,3 +691,11 @@ All five round-trip tests originally listed here are now resolved.
   artifacts; results are recorded inline above.
 - Q-10 trust-gate verification, 2026-09-03 — operator confirmation against
   a real `start.sh`-launched container, outside this session's own testing.
+- Q-12 settings-scope probe, 2026-09-03 — four arms via nested `claude -p`
+  under an isolated `HOME`, Environment 2, Claude Code v2.1.259. Arm C is
+  the negative control; arm D produced the finding tracked as issue #64.
+  Automated as `check-auto-memory.sh deny-scope`, all three arms including
+  the negative control.
+- `docs/designs/auto-memory-seeding.md` — the SDD this pass now feeds.
+- Issue #64 — this repository's `permissions.deny` rules sit at a path
+  Claude Code does not read.

--- a/docs/designs/auto-memory-seeding-step-zero.md
+++ b/docs/designs/auto-memory-seeding-step-zero.md
@@ -389,9 +389,25 @@ removes nothing.
 
 **Arm D is a separate finding — see "Project-scope settings at the wrong path".**
 
-*Caveats: Environment 2, not a `start.sh` container; non-interactive, so the
-workspace-trust dialog was skipped (see below); one trial per arm, model
-`sonnet`.*
+**Re-confirmed in a canonical session, 2026-09-04.** Re-run by the operator via
+`check-auto-memory.sh deny-scope` against a `start.sh`-launched container
+(`claude-claude-sandbox-1788455273`), using that session's own login rather than
+an API key. Same outcome — C not denied, A and B denied — and both transcripts
+attribute the block to the permission system rather than reading as a model
+that declined to try ("The command was denied by permission settings";
+"Permission to run that command was denied"). **The Environment 2 caveat is
+lifted for Q-12.**
+
+That run also corroborates the trust narrowing below, as a byproduct nobody
+designed for: the probe's scratch project at `/tmp/deny-scope-proj` was created
+inside the container and never trusted by anyone, yet its project-scope deny
+rule fired in arms A and B. Settings from an untrusted directory took effect
+under `-p`, which is what "the workspace trust dialog is skipped in
+non-interactive mode" predicts.
+
+*Caveats remaining: the probe's own turns are non-interactive, so the
+workspace-trust dialog was skipped even though the host session is interactive;
+one trial per arm; model `sonnet` in the Environment 2 run.*
 
 ## Project-scope settings at the wrong path — found 2026-09-03
 

--- a/docs/designs/auto-memory-seeding.md
+++ b/docs/designs/auto-memory-seeding.md
@@ -1,7 +1,9 @@
 # Curated Auto-Memory Seeding — Software Design Document
 
 > **Document type:** Software Design Document (SDD)
-> **Status:** Accepted — approved for implementation 2026-09-03
+> **Status:** Accepted, implementation parked 2026-09-03 — the design and its
+> verification gate stand; steps 3–8 are deliberately not executed, for want of
+> content that fits the mechanism. See §9, "Why this is parked."
 > **Classification:** Case E (container security control) + Case C (multi-component feature)
 > **Relates to:** `auto-memory-seeding-step-zero.md` (evidence base),
 > `global-layer-injection.md` (the mechanism this extends),
@@ -510,6 +512,12 @@ exists to serve.
 
 ## 8. Implementation Plan
 
+**Executed: steps 1 and 2 only.** Steps 3–8 are parked, not cancelled — see §9,
+"Why this is parked." They remain accurate as written and can be picked up
+unchanged if seed content appears, though the placement question in §9 should be
+settled first, since it may redirect the work to a per-project layer rather than
+this one.
+
 One logical change per commit, on a branch, referencing the issue.
 
 1. **`docs: design for curated auto-memory seeding (#65)`** — this document.
@@ -553,6 +561,79 @@ would inflate a trivial change with process it does not need.
 
 ## 9. Open Questions and Non-Decisions
 
+### Why this is parked
+
+Steps 1 and 2 landed. Steps 3–8 are not executed, because no content was found
+that the mechanism is actually good at carrying. Recorded in full, because the
+reasoning is the useful part and the next person will otherwise rediscover it.
+
+**Two independent attempts at a seed both landed somewhere else.** The first
+candidate — operator profile, communication, critical-thinking and
+decision-framing preferences — turned out to be `CLAUDE.md` content by this
+document's own §2 test: it must apply on every turn, and topic files load on
+demand (Q-2). It shipped to `global-claude/CLAUDE.md` instead (#66). The second
+candidate was this project's accumulated claude.ai memory, which the operator
+reported as out of sync with the repository's current state.
+
+**Stale content is the failure mode this design cannot absorb.** §6.2 already
+says stale memory is worse than none. The compounding reason is that it is
+unfalsifiable in place: memory is read selectively, so wrong content surfaces on
+some turns and not others, and #46050 means an absent effect is equally
+consistent with the file never being read. "The seed was wrong" and "the seed
+was ignored" produce the same observation. A seed corpus whose failures cannot
+be told apart from its successes is not worth carrying.
+
+**The outcome was predicted.** The informal proposal's answer on claude.ai
+memory held that the exercise would surface documentation *gaps* rather than
+net-new content, because the project's SDD and `CLAUDE.md` practice already
+captures what is durable in reviewed form. Two attempts later, that is what
+happened. This is evidence about the content, not about the search for it.
+
+**What is not lost.** The design record stands with its alternatives and STRIDE
+analysis; Q-12 closed a real question; `check-auto-memory.sh deny-scope` is a
+reusable instrument; and the probe that cleared the gate found #64, a live gap
+in an existing control. None of that depends on seeding shipping.
+
+**What would unpark it:** seed content that is genuinely looked up rather than
+always applicable, and that is not already in the documentation. The gap audit
+in the next entry is the cheapest way to find out whether any exists.
+
+### The seed's placement and memory's natural unit do not match
+
+Named here because it went unnoticed while the design was written, and it
+explains the empty corpus better than any shortage of effort does.
+
+Memory's natural content is **per-project** facts. This design places the seed
+in `global-claude/`, which `start.sh` mounts for *every* project. So the
+mechanism can only carry cross-project content — and cross-project content that
+is always applicable belongs in `CLAUDE.md`, as #66 demonstrated, while
+cross-project content that is genuinely on-demand is a thin category. The design
+has nowhere to put the content type memory is best at.
+
+This is not an error in the design as scoped: §1.1 scoped it to the global
+layer, and within that scope every decision here holds. It is a limit of the
+scope itself, and it bounds the feature's value more tightly than §6.1 states.
+
+`config.sh` already carries the `@name` project registry
+(`named-project-registry.md`), so a per-project seed layer has an obvious key
+and an obvious precedent. If seeding is worth building at all, that is likely
+the version worth building — designed deliberately, with its own collision and
+trust questions answered, not bolted onto this one.
+
+### The claude.ai memory dump is a documentation audit, not a seed source
+
+There is no export bridge in either direction, so any such content arrives by
+the operator reading and transcribing it. Given the staleness above, the
+transcription is worth doing for a different purpose: diff each remembered item
+against the repository. An item matching a document is already captured and gets
+discarded; an item contradicting one is stale, and the check is which of the two
+is wrong; an item genuinely absent from the documentation is a gap, and the fix
+is the **document**, not the seed.
+
+Whatever survives all three is by construction the only legitimate seed
+candidate. If nothing survives, that is the answer, and it cost one session plus
+a documentation pass that was worth doing anyway.
+
 **Q: Should per-image memory overlays exist (`global-crypto/memory/`, …)?**
 
 Deferred, same posture as the per-image overlays themselves: empty until a real
@@ -583,6 +664,14 @@ in this design creates or forecloses one.
 ---
 
 ## Changelog
+
+### Version 1.2 — 2026-09-03
+Parked implementation at step 2. Two attempts at seed content both landed
+outside the mechanism — the first in `CLAUDE.md` (#66), the second stale — and
+§9 now records why, along with the placement mismatch that explains it: the seed
+rides the global layer while memory's natural unit is per-project. Steps 3–8 are
+retained as written rather than deleted, since the design holds; what is in
+question is whether this scope is the right home for the feature.
 
 ### Version 1.1 — 2026-09-03
 Downgraded the `autoMemoryDirectory`-preservation question from a blocking gate

--- a/docs/designs/auto-memory-seeding.md
+++ b/docs/designs/auto-memory-seeding.md
@@ -1,0 +1,601 @@
+# Curated Auto-Memory Seeding — Software Design Document
+
+> **Document type:** Software Design Document (SDD)
+> **Status:** Accepted — approved for implementation 2026-09-03
+> **Classification:** Case E (container security control) + Case C (multi-component feature)
+> **Relates to:** `auto-memory-seeding-step-zero.md` (evidence base),
+> `global-layer-injection.md` (the mechanism this extends),
+> `docs/claude_code_security_plan.md` (STRIDE coverage map)
+> **Audience:** The engineer maintaining this sandbox — assumes the global
+> layer's copy-on-start model and the existing STRIDE coverage map are known.
+
+---
+
+## 1. Purpose and Scope
+
+### 1.1 What this designs
+
+Seeding operator-authored Auto Memory content into every sandbox session:
+curated, git-tracked, delivered read-only at session start, destroyed with the
+container. This is "Option A" from `injecting_memories_into_containers.md` — the
+one-way seed, not round-trip persistence.
+
+The empirical groundwork is `auto-memory-seeding-step-zero.md`. Findings are
+cited here by their identifiers (F-1, Q-4, R-2, …) and **not restated**; that
+document is the record, this one is the decision.
+
+### 1.2 Why the design changed from the informal proposal
+
+The informal proposal predates the research pass and predates a close reading of
+the entrypoint. Two of its components turn out to be unnecessary:
+
+- It proposed a dedicated `/run/claude-memory` readonly mount and a matching
+  `cp` block. `entrypoint.sh:26` already copies `/run/claude-global/.` into
+  `~/.claude/`, so a `global-claude/memory/` directory arrives at
+  `~/.claude/memory/` with no new mount and no new copy code.
+- It proposed entrypoint logic to *write* `~/.claude/settings.json`. A
+  `global-claude/settings.json` file rides the same copy and needs no logic.
+
+What the entrypoint does gain is the one thing static files cannot provide: a
+check that the seed is loadable. Q-4 established that an oversized `MEMORY.md`
+loses its tail silently, and Q-3 that malformed frontmatter is silently tolerated
+and never self-corrects. Both failure modes are invisible from inside the
+session, which is precisely the case for a startup check.
+
+### 1.3 Non-goals
+
+- **No write-back or memory promotion** (Option B). The standing decision in
+  `global-layer-injection.md` §9 holds, for the reasons in §5.4.
+- **No rule enforcement.** Per step-zero's Scope decision, seeded content is
+  advisory. Guardrails remain `permissions.deny`, Squid, and the container
+  posture. Nothing in this design makes memory a control.
+- **No claude.ai account or project memory ingestion.** No bridge exists in
+  either direction; any such content arrives by the operator reading and
+  transcribing it, as a content edit.
+- **No consolidation step** ("Auto Dream" and equivalents).
+- **No per-image memory overlay.** Deferred — see §9.
+- **No Claude Code version pin.** A stated precondition (§6.3), not scope; it is
+  a dependency-management decision meriting its own ADR.
+
+---
+
+## 2. Current Structure
+
+```
+host                          container (ephemeral)
+────                          ─────────────────────
+global-claude/  ──readonly──► /run/claude-global
+  CLAUDE.md                        │  cp -r  (entrypoint.sh:26)
+  skills/                          ▼
+  hooks/                      ~/.claude/
+  templates/                    CLAUDE.md, skills/, hooks/, templates/
+
+                              ~/.claude/projects/-workspace/memory/
+                                MEMORY.md          ← written by Claude
+                                <topic>.md            during the session,
+                                                      destroyed on --rm
+                              ~/.claude/settings.json   ← does not exist
+```
+
+Auto Memory is active by default (F-1) and writes to a path derived from the
+workspace mount (F-2). Nothing seeds it: every session begins with no memory and
+accumulates from zero for the container's lifetime. `~/.claude/settings.json` is
+absent in a `start.sh` container, and nothing in this repository writes it.
+
+This is not a defect. It is the ephemerality guarantee working as designed — it
+is simply also the reason a session cannot start from operator-curated context
+the way it does for `CLAUDE.md`.
+
+**Why not just put the content in `CLAUDE.md`.** `CLAUDE.md` is loaded eagerly
+and in full, every session. Memory topic files are read on demand (Q-2), so a
+corpus that grows past what is worth spending context on every turn belongs in
+memory rather than in `CLAUDE.md`. That difference is the entire reason this
+feature exists; if the seed stays small enough to live in `CLAUDE.md`, it should.
+
+---
+
+## 3. Target Structure
+
+```
+host                          container (ephemeral)
+────                          ─────────────────────
+global-claude/  ──readonly──► /run/claude-global
+  CLAUDE.md                        │  cp -r  (UNCHANGED)
+  skills/                          ▼
+  hooks/                      ~/.claude/
+  templates/                    CLAUDE.md, skills/, hooks/, templates/
+  settings.json   ← NEW         settings.json   {"autoMemoryDirectory":
+  memory/         ← NEW                            "~/.claude/memory"}
+    MEMORY.md                   memory/
+    <type>_<topic>.md             MEMORY.md      ← seed, then writable
+                                  <type>_<topic>.md
+
+                              ~/.claude/projects/-workspace/memory/
+                                (shadowed — left in place, not consulted; Q-9)
+
+entrypoint.sh  + inspect-and-warn block (§4.3)
+start.sh       UNCHANGED
+base/Dockerfile UNCHANGED
+```
+
+Three changes, in descending order of significance:
+
+1. **`global-claude/memory/`** — the curated seed corpus. Authored and reviewed
+   exactly like `global-claude/CLAUDE.md`; no Claude-authored content ever enters
+   the host source.
+2. **`global-claude/settings.json`** — a user-scope settings file whose only key
+   is `autoMemoryDirectory`, pointing at `~/.claude/memory`.
+3. **`base/entrypoint.sh`** — a validation block that reports, and never blocks.
+
+---
+
+## 4. Component Design
+
+### 4.1 The seed corpus — authoring contract
+
+`global-claude/memory/` holds a `MEMORY.md` index and topic files, following the
+format established in F-3, F-4 and R-2. What the corpus must and must not assert
+is settled by step-zero's validator table; the operator-facing rules are:
+
+| Rule | Source |
+|---|---|
+| `MEMORY.md` ≤ 200 lines **and** ≤ 25KB | Q-4 — silent truncation on read |
+| Topic frontmatter must parse as YAML | F-3, Q-3 — never self-corrects |
+| `metadata.type` ∈ `user`/`feedback`/`project`/`reference` | R-2 |
+| Do **not** author `metadata.node_type` | Q-6 — undocumented internal |
+| Do **not** author `metadata.originSessionId` | Q-7 — backfilled regardless |
+| Do **not** rely on the index-line grammar as a contract | Q-1 — not parsed |
+| Do **not** encode a filename convention | F-5 — Inferred, n=2 |
+
+Two content rules are this document's own, not inherited:
+
+- **No secrets, credentials, or host paths outside `/workspace`.** Seed content
+  is loaded into the model's context on every session and is therefore subject to
+  the same discipline as `CLAUDE.md` (§5.3).
+- **Advisory phrasing only.** Content that reads as an enforced rule invites
+  exactly the misplaced reliance the Scope decision rules out. Constraints belong
+  in `settings.json`'s `permissions` block or in Squid.
+
+### 4.2 `global-claude/settings.json`
+
+```json
+{
+  "autoMemoryDirectory": "~/.claude/memory"
+}
+```
+
+**Why override rather than seed the default path.** The default is derived from
+the workspace mount, and `/workspace` is fixed in this project — so seeding
+`global-claude/projects/-workspace/memory/` would work today. It is nonetheless
+the wrong choice: F-2 is an `n=1` observation of an undocumented derivation rule,
+and step-zero's Standing Risk consequence #1 is to assert only what is Confirmed.
+`autoMemoryDirectory` is a documented contract with a confirmed value form
+(Q-9), so the design depends on the documented mechanism rather than on an
+inferred internal convention. Q-9 also confirmed the shadow semantics: the
+default directory is left in place and simply not consulted, so no stale content
+competes with the seed.
+
+**Ownership.** The entrypoint does not merge this file; the copy overwrites
+whatever is at the destination, which in a `start.sh` container is nothing. This
+is adequate *only* while `autoMemoryDirectory` is the sole user-scope key. The
+moment a second consumer wants one, this becomes a real merge and needs JSON
+handling — flagged here so it is a known limit rather than a discovered one.
+
+**Name collision, stated to prevent confusion.** The repository root already
+contains a `settings.json`. That is the *project-scope* permissions file for
+this repo, is not mounted into any container, and is untouched by this design.
+The new file is a distinct, user-scope file inside `global-claude/`.
+
+**Interaction verified — gate cleared 2026-09-03.** Introducing a user-scope
+`settings.json` does not disturb project-scope `permissions.deny`. Confirmed by
+round-trip test, recorded as Q-12 in step-zero: with the deny rule at
+`.claude/settings.json`, the rule fired identically with and without a
+user-scope file carrying only `autoMemoryDirectory`, and a negative-control arm
+established that the probe was capable of *not* denying — without which the two
+matching results would have licensed the conclusion while testing nothing.
+`check-auto-memory.sh deny-scope` is the instrument, and re-running it in a
+`start.sh` container remains owed: the confirming run was Environment 2 and
+non-interactive.
+
+**Second interaction, deliberately not gated.** Claude Code may itself write
+`~/.claude/settings.json` during a session (theme, model). Whether such a write
+preserves `autoMemoryDirectory` or replaces the file wholesale is unknown, and
+is **accepted as a documented risk rather than verified**, for three reasons:
+
+- The blast radius is small and bounded. The seed has already loaded at session
+  start — that value is banked. What a wholesale replace costs is where *later*
+  writes land and whether the seeded corpus stays consulted: a quality
+  degradation, ephemeral, contained by `--rm`.
+- It is not cheaply testable. There is no `config` subcommand in the CLI
+  (verified against v2.1.259), so a settings write cannot be forced from the
+  command line; observing one needs an interactive TTY session and a manual
+  `/config` change.
+- The answer would not keep. This is an implementation detail of an unpinned
+  binary (§6.3), so a confirmed result expires on the next rebuild with no diff
+  to signal it, leaving a manual test to re-run indefinitely for a fact that
+  decays.
+
+**Detection instead of verification.** `check-memory-seed.sh diff` (§4.4) dumps
+the seed beside its live state in a running container, so a reverted
+`autoMemoryDirectory` shows up as the seeded corpus sitting unconsulted while
+memory accumulates at the default path. That is a byproduct of a tool this design
+already builds, it observes rather than remembers, and it stays true across
+version drift. A confirmed instance gets recorded in step-zero and reopens this
+decision; until then the risk is carried, not chased.
+
+### 4.3 The entrypoint validation block
+
+Placed after the existing copy blocks, before `exec "$@"`, following the shape of
+the commit-msg drift check (`entrypoint.sh:110-170`):
+
+```
+[entrypoint] Checking seeded Auto Memory content
+[entrypoint] OK: MEMORY.md is 41 lines, 2114 bytes (limits: 200 lines, 25600 bytes)
+[entrypoint] OK: frontmatter delimiters present in 3 topic file(s)
+[entrypoint] Seeded Auto Memory check complete
+```
+
+Checks performed:
+
+1. **Size**, against both ceilings independently — `wc -l` and `wc -c` on
+   `~/.claude/memory/MEMORY.md`. Exact, not approximate. This is the one
+   step-zero marks Mandatory.
+2. **Frontmatter structure** on each topic file — leading `---`, a closing `---`,
+   and balanced quoting on `description`. This deliberately is *not* a YAML
+   parse.
+3. **Absent seed** — reports "no seeded memory content" and continues. Seeding is
+   optional; a session without a seed is the current behavior and stays valid.
+
+**Why not a real YAML parse.** Verified during design: neither the image nor the
+host has a YAML parser (`python3 -c 'import yaml'` → `ModuleNotFoundError`; only
+`python3` and `node` are present). Getting one means adding a package to
+`base/Dockerfile` — widening the image and the Case E surface — to run a
+pre-filter that step-zero already says is not the authoritative check. The
+structural check catches the failure Q-3 actually exercised (an unterminated
+quoted string) at zero dependency cost. Its limits are stated in the log and in
+§6.2 rather than papered over; a structurally valid file that is invalid YAML
+will pass this check and fail silently in the session.
+
+**Why warn and never block.** Every existing entrypoint check warns. Fail-closed
+is correct for Squid, which is a security control; a malformed advisory seed is a
+quality defect, and aborting a session over it would be disproportionate and
+would make a broken seed more damaging than no seed. The operator sees the
+warning at the top of every session until it is fixed.
+
+### 4.4 `check-memory-seed.sh` — host-side diagnostic
+
+A repo-root script mirroring `check-auto-memory.sh`'s conventions (same
+`config.sh` precedence, same subcommand shape, same "starts nothing it does not
+have to" posture):
+
+- `validate [dir]` — the full authoring contract from §4.1 against
+  `global-claude/memory/`, including the checks the entrypoint cannot cheaply
+  make (`metadata.type` membership, `node_type`/`originSessionId` absence, index
+  links resolving). Runs on the host, before a session, with no container needed.
+- `diff <container>` — dumps the seed as authored beside the same files as they
+  stand in a live container, so in-session drift is observable. This is the
+  operator-facing answer to informal-proposal step-zero item 4.
+
+Splitting the thorough check onto the host and the cheap check into the
+entrypoint is deliberate: the host check can be run and fixed before a session
+exists, which is where a seeding mistake is cheapest to correct.
+
+### 4.5 Test plan
+
+New tests in `tests/test_global_layer.bats`, continuing the `G-` numbering. G-4
+stays as it is — it asserts non-leakage of arbitrary writes and is not a seeding
+test.
+
+| Test | Asserts |
+|---|---|
+| G-10 | A seeded `global-claude/memory/` arrives at `~/.claude/memory/` in a session |
+| G-11 | `~/.claude/settings.json` is present and declares `autoMemoryDirectory` |
+| G-12 | The project-scope `permissions.deny` rules G-6 asserts are still declared with the user-scope file present |
+| G-13 | An oversized `MEMORY.md` fixture is reported as a warning by the entrypoint |
+| G-14 | A malformed-frontmatter fixture is reported as a warning by the entrypoint |
+| G-15 | A container with no seed reports "no seeded memory content" and starts normally |
+
+G-13/G-14/G-15 assert on entrypoint stdout, following G-7/G-8's precedent where
+the log line *is* the control's observable output. Fixtures go under
+`tests/fixtures/`, alongside `global-overlay-fixture`.
+
+**What these tests cannot cover.** SDD §7.2 forbids `ANTHROPIC_API_KEY` in the
+suite, so no bats test can drive a live turn. Everything here asserts delivery
+and detection; that the model *loads* and *uses* the seed is confirmed by
+round-trip observation (step-zero's method), recorded in the doc, not automated.
+This is the same documented residual G-6 already carries, and is stated rather
+than left implicit.
+
+---
+
+## 5. STRIDE Impact
+
+Case E obligation. Delta against the coverage map in
+`docs/claude_code_security_plan.md` §5.
+
+### 5.1 Surfaces changed
+
+| Surface | Change |
+|---|---|
+| `global-claude/` content | New content type (memory seed). Same trust model as `CLAUDE.md`: operator-authored, git-reviewed, readonly-mounted, non-root copy. |
+| `~/.claude/settings.json` | **New.** First time anything in this repository writes a user-scope settings file. |
+| Auto Memory write path | Redirected from `~/.claude/projects/-workspace/memory/` to `~/.claude/memory/`. Both are inside the ephemeral home the entrypoint already owns. |
+| `base/entrypoint.sh` | One read-only inspection block. Reads two locations under `$HOME`; writes nothing; changes no control. |
+
+No mount is added, no capability is granted, no network path changes, and
+`start.sh`, `base/Dockerfile`, `squid/squid.conf` and the `permissions` block are
+all untouched.
+
+### 5.2 Controls added
+
+| Threat | Control |
+|---|---|
+| **Denial of Service (D)** | The size check closes Q-4's silent-truncation path. Prior to it, an oversized index loses its tail with no signal anywhere; this is a availability-of-context defect, and the check is the only thing that surfaces it. |
+| **Repudiation (R)** | The entrypoint logs what was seeded and whether it was loadable, so a session's starting memory state is recorded in container logs rather than inferred. `check-memory-seed.sh diff` extends this to in-session drift. |
+| **Tampering (T)** | The seed source is readonly-mounted and git-tracked, so the corpus that reaches a session has a review trail — the same Repudiation/Tampering pairing the global layer already relies on. |
+
+### 5.3 Risks accepted, with reasoning
+
+**Tampering — the session may rewrite its own seed.** `~/.claude/memory/` is
+writable, and Q-8 confirmed that read-without-write is not achievable by
+configuration. A session can therefore overwrite seeded content mid-run. This is
+accepted, not mitigated, per the Scope decision: for advisory content, divergence
+between the seed and the file twenty minutes in is a quality question
+indistinguishable in kind from ordinary reasoning drift. It is bounded by the
+container — the host source is readonly and unreachable (G-3, G-4) — and dies
+with `--rm`. Were policy-class content ever seeded, this would stop being
+acceptable and would need `permissions.deny` on that path; that is why §1.3 rules
+such content out rather than leaving it to judgment.
+
+**Information disclosure — seed content is context, permanently.** Anything in
+the corpus is in the model's context every session, and would appear in any
+transcript or bug report. The §4.1 no-secrets rule is the control, and it is a
+review-time human control, not an enforced one — the same standing as the
+equivalent rule for `CLAUDE.md`.
+
+**Tampering — `autoMemoryDirectory` is settable from project scope.** Q-10
+overturned the informal proposal's premise here: the setting is honored from any
+scope, so a mounted untrusted repository *can* carry one. This is **pre-existing
+and not introduced by this design** — it is true today, with no seeding. The
+control is workspace trust, verified live against a real `start.sh` container: an
+untrusted clone's entry does not take effect until a human accepts the trust
+prompt. Recorded here because this design is what makes the surface worth
+naming, and because seeding must not be built in a way that bypasses that gate —
+it does not, since it operates entirely in user scope.
+
+**The trust gate is narrower than step-zero recorded it.** `claude --help`
+states, for `-p`, that "the workspace trust dialog is skipped when Claude is run
+in non-interactive mode (via `-p`, or when stdout is not a TTY, e.g. piped or
+redirected output)", and that settings files failing validation are silently
+ignored in that mode with no error shown. Step-zero's verification exercised the
+interactive path, which is the path `start.sh` takes — it runs `-it`, so
+production is correctly gated and that finding stands for production. It does
+**not** generalise to every invocation inside the container: a `claude -p` run,
+or any run whose stdout is piped or redirected, skips the dialog, and a mounted
+repository's project-scope settings — `autoMemoryDirectory` among them — take
+effect with no human in the loop.
+
+Consequences, in order of importance:
+
+- The exposure §5.3 describes as closed is closed *for the interactive session
+  `start.sh` starts*, not for arbitrary in-container use. Anyone scripting
+  `claude -p` against an untrusted mounted repository is outside the control.
+- `check-auto-memory.sh deny-scope` drives non-interactive turns and therefore
+  runs on the ungated path by construction. Its result transfers to a real
+  session by analogy, not proof — the same standing as step-zero's Environment 2
+  findings, and stated in the script itself.
+- This qualification belongs in step-zero's "Pre-existing exposure" section as a
+  correction, since that is where the original conclusion is recorded. §8 step 2
+  carries it.
+
+### 5.4 Why no write-back, restated as a control decision
+
+Option B remains closed, and the reason is now citable rather than intuitive.
+Memory poisoning is a named threat class (OWASP ASI06), and the published
+attacks bear directly on this shape: MINJA reports high injection success through
+ordinary interaction with no privileged access, and MemoryGraft — the closest to
+this architecture — shows benign-looking ingested artifacts, of exactly the kind
+a coding agent reads from `/workspace` as normal work, inducing durable
+fabricated "experience" that resurfaces in later, unrelated tasks. A write-back
+path would carry that across the container boundary the ephemerality guarantee
+exists to hold. Independent defense work converges on separating untrusted
+candidate memory from trusted memory behind mediated promotion, which is the
+human review gate `global-layer-injection.md` §9 already prescribes.
+
+No other STRIDE category is affected. Spoofing and Elevation of Privilege are
+untouched: no identity, credential, capability, or privilege boundary changes.
+
+### 5.5 Residual, not closed
+
+- The structural frontmatter check is not a YAML parse (§4.3). A file that is
+  structurally plausible but invalid YAML passes and then fails silently in the
+  session.
+- No test drives a live turn, so "the seed is delivered" is automated while "the
+  seed is loaded and used" stays a manual round-trip observation (§4.5).
+- Upstream issue #46050 — topic files are often not read proactively even when
+  correctly indexed. A correct seed can still go unread. Nothing in this design
+  can fix that; it bounds what seeding achieves (§6.1).
+- The memory format is unversioned (Q-11) and Claude Code is unpinned (§6.3).
+- Whether Claude Code preserves `autoMemoryDirectory` when it rewrites
+  `~/.claude/settings.json` is unverified and deliberately so (§4.2). Detected
+  by `check-memory-seed.sh diff`, not prevented.
+- Workspace trust does not gate non-interactive invocations inside the container
+  (§5.3). Not introduced here and not closed here; `start.sh`'s own path is
+  interactive and unaffected.
+
+---
+
+## 6. Consequences
+
+### 6.1 What this buys, honestly bounded
+
+A session starts knowing what the operator curated, with the lazy-loading
+property `CLAUDE.md` lacks. It does not guarantee the model reads any given topic
+file (#46050), and it enforces nothing. The realistic claim is *fewer wasted
+turns rediscovering established context*, not *the agent now behaves correctly*.
+
+### 6.2 What gets harder
+
+- A second reviewed corpus to keep current. Stale memory content is worse than
+  none — it is confidently wrong context, and unlike `CLAUDE.md` it is read
+  selectively, so staleness surfaces unpredictably.
+- The 200-line/25KB budget is a hard ceiling shared by all seeded index content.
+- `~/.claude/settings.json` now has an owner, and the next key added to it turns
+  a file copy into a merge (§4.2).
+
+### 6.3 Precondition, not scope
+
+`base/Dockerfile:66` installs `@anthropic-ai/claude-code` unpinned. Q-11 confirms
+the memory format has already changed once in a version-visible way, so the
+authoring contract in §4.1 can drift with no diff in this repository to signal
+it. This design mitigates rather than solves that: the entrypoint check asserts
+only size and structure — the two properties least likely to move — and §4.1
+asserts nothing marked Inferred. Pinning is the real answer and is deliberately
+out of scope, as a dependency-management decision that constrains the project
+beyond this feature and merits its own ADR.
+
+---
+
+## 7. Alternatives Considered
+
+**Chose:** static seed files riding the existing copy, plus an entrypoint check.
+**Rejected:** static files with no check at all.
+*Why the rejected option is attractive:* it is a pure content change — no shell
+code, no Case E code obligation, the smallest possible diff, and the existing
+`cp -r` already does the work.
+*What breaks if you try it anyway:* Q-4's truncation and Q-3's malformed
+frontmatter are both silent and both invisible from inside the session. The
+corpus would appear to work while its tail entries were never loaded. Step-zero
+marks the size assertion Mandatory precisely because nothing else surfaces it.
+
+**Chose:** files ride `/run/claude-global`.
+**Rejected:** a dedicated `/run/claude-memory` mount with its own merge block
+(the informal proposal).
+*Why the rejected option is attractive:* explicit and symmetric with the overlay
+mount; a reader sees memory injection called out by name in `start.sh`.
+*What breaks if you try it anyway:* nothing breaks — it duplicates working
+plumbing. It adds a mount, a `start.sh` conditional and a copy block that must
+each be maintained and tested, to achieve what `entrypoint.sh:26` already does.
+
+**Chose:** `autoMemoryDirectory` override.
+**Rejected:** seeding the default derived path, `~/.claude/projects/-workspace/memory/`.
+*Why the rejected option is attractive:* it removes the settings.json surface
+entirely — the only genuinely new surface in this design — and the path is stable
+in this project because `/workspace` is fixed.
+*What breaks if you try it anyway:* it hardcodes an undocumented derivation rule
+observed once (F-2), against step-zero's own rule to assert only what is
+Confirmed. If the rule changes, the seed lands somewhere nothing reads, and the
+entrypoint check would pass on a file the session never loads.
+
+**Chose:** structural frontmatter check.
+**Rejected:** adding a YAML parser to `base/Dockerfile` for a real parse.
+*Why the rejected option is attractive:* a one-line apt addition buys a correct
+check instead of an approximation, and closes §5.5's first residual.
+*What breaks if you try it anyway:* it widens the image and the Case E surface to
+strengthen a pre-filter that step-zero explicitly says is not the authoritative
+gate — the round-trip observation is. The correctness gained is real but small;
+the dependency is permanent.
+
+**Chose:** memory seed.
+**Rejected:** putting the content in `global-claude/CLAUDE.md`.
+*Why the rejected option is attractive:* zero new mechanism, zero new surface,
+one corpus instead of two, and it is the path `global-layer-injection.md` §9
+already prescribes for insights worth keeping.
+*What breaks if you try it anyway:* nothing, for a small corpus — and for a small
+corpus it remains the right answer (§2). It stops scaling when the corpus exceeds
+what is worth loading eagerly every turn, which is the condition this design
+exists to serve.
+
+---
+
+## 8. Implementation Plan
+
+One logical change per commit, on a branch, referencing the issue.
+
+1. **`docs: design for curated auto-memory seeding (#65)`** — this document.
+2. **Verification gate — cleared 2026-09-03, re-confirmation owed.** The
+   settings-scope question passed in Environment 2 (step-zero Q-12), so the work
+   below is unblocked. Re-run `./check-auto-memory.sh deny-scope` in a
+   `start.sh` container before step 3 lands, since the confirming run was
+   non-interactive and outside a canonical session. Two documentation commits
+   fall out of this step and may land independently of the rest:
+   `docs: record the settings-scope probe result` and
+   `docs: narrow the trust-gate finding to interactive sessions` — both already
+   written into step-zero, both true today and neither dependent on seeding
+   shipping.
+
+   **On a separate track:** the probe's arm D established that this repository's
+   `permissions.deny` rules sit at a path Claude Code does not read (step-zero,
+   "Project-scope settings at the wrong path"). That is a Case E defect in an
+   existing control, not a seeding concern — tracked as issue #64. It does not
+   block seeding, but it should not queue behind it either.
+3. **`feat: seed curated auto-memory content into every session (#65)`** —
+   `global-claude/settings.json` and `global-claude/memory/` with a minimal,
+   genuinely useful seed. Small on purpose: the mechanism is what is under test.
+4. **`feat: check seeded auto-memory content at session start (#65)`** — the
+   entrypoint block (§4.3). Case E code change.
+5. **`feat: add check-memory-seed.sh authoring validator (#65)`** — §4.4.
+6. **`test: cover auto-memory seeding and its startup checks (#65)`** — G-10
+   through G-15 plus fixtures.
+7. **`docs: record auto-memory seeding as Change 22 (#65)`** — the §5 STRIDE delta
+   into `docs/claude_code_security_plan.md`, in the established Change format.
+8. **`docs: document memory seeding for operators (closes #65)`** — `user_guide.md`
+   and `ARCHITECTURE.md`.
+
+Steps 3–6 are each independently revertible. Step 2 gates all of them.
+
+**Separately, not on this branch:** restore the "Identity and scope" section to
+`global-claude/CLAUDE.md`, which the original global-layer plan drafted and the
+shipped file lost. It is a plain content edit, Case A/B, and bundling it here
+would inflate a trivial change with process it does not need.
+
+---
+
+## 9. Open Questions and Non-Decisions
+
+**Q: Should per-image memory overlays exist (`global-crypto/memory/`, …)?**
+
+Deferred, same posture as the per-image overlays themselves: empty until a real
+need appears. Worth recording that the path is free — `entrypoint.sh:33` already
+copies `/run/claude-overlay/.` into `~/.claude/`, so `global-<image>/memory/`
+would be delivered today with no code change. Adopting it later is a content
+decision plus a collision-semantics decision (does an overlay `MEMORY.md` replace
+the base one, or are they merged), not a mechanism decision. The collision
+question is real and is the reason not to do it speculatively.
+
+**Q: Should the entrypoint block a session on an invalid seed?**
+
+No, decided in §4.3. Recorded because the opposite instinct is reasonable and
+will recur: every other fail-closed decision in this project (Squid) concerns a
+security control, and this is not one.
+
+**Q: What content should actually be seeded?**
+
+Not decided here beyond the §4.1 rules. Step 3 ships a minimal seed to exercise
+the mechanism; growing the corpus is ordinary reviewed content work.
+
+**Q: Does seeding change how Option B should be designed?**
+
+No. Step-zero's Q-7 already killed the `originSessionId` provenance marker, so a
+future promotion design needs a different provenance carrier regardless. Nothing
+in this design creates or forecloses one.
+
+---
+
+## Changelog
+
+### Version 1.1 — 2026-09-03
+Downgraded the `autoMemoryDirectory`-preservation question from a blocking gate
+to a documented risk with a detector (§4.2), on the grounds that its blast radius
+is a quality degradation, it is not cheaply testable (no `config` subcommand
+exists in v2.1.259), and the answer decays with every unpinned rebuild. Added the
+`deny-scope` probe to `check-auto-memory.sh` as the instrument for the one gate
+that remains. Narrowed step-zero's trust-gate conclusion to interactive sessions
+(§5.3): `-p`, and any run whose stdout is not a TTY, skips the workspace trust
+dialog.
+
+### Version 1.0 — 2026-09-03
+Initial design document. Supersedes the informal proposal in
+`injecting_memories_into_containers.md` on three points: no dedicated mount, no
+entrypoint-written settings file, and `autoMemoryDirectory`'s scope enforcement
+(Q-10 overturned the user/policy-only premise the proposal was written under).

--- a/docs/designs/auto-memory-seeding.md
+++ b/docs/designs/auto-memory-seeding.md
@@ -301,12 +301,17 @@ G-13/G-14/G-15 assert on entrypoint stdout, following G-7/G-8's precedent where
 the log line *is* the control's observable output. Fixtures go under
 `tests/fixtures/`, alongside `global-overlay-fixture`.
 
-**What these tests cannot cover.** SDD §7.2 forbids `ANTHROPIC_API_KEY` in the
-suite, so no bats test can drive a live turn. Everything here asserts delivery
-and detection; that the model *loads* and *uses* the seed is confirmed by
-round-trip observation (step-zero's method), recorded in the doc, not automated.
-This is the same documented residual G-6 already carries, and is stated rather
-than left implicit.
+**What these tests cannot cover.** No bats test can drive a live turn. The
+testing SDD's §7.2 forbids `ANTHROPIC_API_KEY` in the suite, and independently
+of that ban there is no key to forbid: nothing in this project's launch path
+carries credentials into a container — `start.sh` passes only `GH_TOKEN` — so a
+session is authenticated because a human logged into it. An automated test has
+no session to inherit that from.
+
+Everything here therefore asserts delivery and detection; that the model *loads*
+and *uses* the seed is confirmed by round-trip observation (step-zero's method),
+recorded in the doc, not automated. This is the same documented residual G-6
+already carries, and is stated rather than left implicit.
 
 ---
 
@@ -523,9 +528,12 @@ One logical change per commit, on a branch, referencing the issue.
 1. **`docs: design for curated auto-memory seeding (#65)`** — this document.
 2. **Verification gate — cleared 2026-09-03, re-confirmation owed.** The
    settings-scope question passed in Environment 2 (step-zero Q-12), so the work
-   below is unblocked. Re-run `./check-auto-memory.sh deny-scope` in a
-   `start.sh` container before step 3 lands, since the confirming run was
-   non-interactive and outside a canonical session. Two documentation commits
+   below is unblocked. Re-confirm before step 3 lands, since the confirming run
+   was non-interactive and outside a canonical session: start a session with
+   `./start.sh`, log into it, then run
+   `./check-auto-memory.sh deny-scope <container-name>` from the host. The probe
+   reuses that session's login — there is no API key in this project's launch
+   path to pass instead. Two documentation commits
    fall out of this step and may land independently of the rest:
    `docs: record the settings-scope probe result` and
    `docs: narrow the trust-gate finding to interactive sessions` — both already

--- a/docs/designs/auto-memory-seeding.md
+++ b/docs/designs/auto-memory-seeding.md
@@ -195,9 +195,10 @@ round-trip test, recorded as Q-12 in step-zero: with the deny rule at
 user-scope file carrying only `autoMemoryDirectory`, and a negative-control arm
 established that the probe was capable of *not* denying — without which the two
 matching results would have licensed the conclusion while testing nothing.
-`check-auto-memory.sh deny-scope` is the instrument, and re-running it in a
-`start.sh` container remains owed: the confirming run was Environment 2 and
-non-interactive.
+`check-auto-memory.sh deny-scope` is the instrument. **Re-confirmed in a
+`start.sh` container 2026-09-04**, so the Environment 2 caveat no longer
+applies; the probe's turns remain non-interactive, which is recorded in
+step-zero and in the script.
 
 **Second interaction, deliberately not gated.** Claude Code may itself write
 `~/.claude/settings.json` during a session (theme, model). Whether such a write
@@ -388,9 +389,11 @@ Consequences, in order of importance:
   `start.sh` starts*, not for arbitrary in-container use. Anyone scripting
   `claude -p` against an untrusted mounted repository is outside the control.
 - `check-auto-memory.sh deny-scope` drives non-interactive turns and therefore
-  runs on the ungated path by construction. Its result transfers to a real
-  session by analogy, not proof — the same standing as step-zero's Environment 2
-  findings, and stated in the script itself.
+  runs on the ungated path by construction, even when hosted inside an
+  interactive session. The 2026-09-04 run demonstrated the exposure rather than
+  merely describing it: the probe's scratch project was never trusted by anyone,
+  and its project-scope deny rule took effect anyway. Stated in the script
+  itself, so the limit travels with the instrument.
 - This qualification belongs in step-zero's "Pre-existing exposure" section as a
   correction, since that is where the original conclusion is recorded. §8 step 2
   carries it.
@@ -526,10 +529,10 @@ this one.
 One logical change per commit, on a branch, referencing the issue.
 
 1. **`docs: design for curated auto-memory seeding (#65)`** — this document.
-2. **Verification gate — cleared 2026-09-03, re-confirmation owed.** The
-   settings-scope question passed in Environment 2 (step-zero Q-12), so the work
-   below is unblocked. Re-confirm before step 3 lands, since the confirming run
-   was non-interactive and outside a canonical session: start a session with
+2. **Verification gate — cleared and re-confirmed 2026-09-04.** The
+   settings-scope question passed in Environment 2 and again in a
+   `start.sh`-launched container (step-zero Q-12), so nothing below is blocked
+   on it. To re-run after a Claude Code upgrade: start a session with
    `./start.sh`, log into it, then run
    `./check-auto-memory.sh deny-scope <container-name>` from the host. The probe
    reuses that session's login — there is no API key in this project's launch


### PR DESCRIPTION
Closes #65, which is rescoped to the design and its verification gate.
Implementation is parked — see "What is not landing".

## What lands

- `docs/designs/auto-memory-seeding.md` — the SDD: design, alternatives
  considered, STRIDE impact, implementation plan.
- `check-auto-memory.sh deny-scope` — a three-arm probe for the design's
  blocking gate. Needs credentials, so it is an operator-run diagnostic and not
  part of `bats tests/`.
- Step-zero gains Q-12 (the gate result), a narrowing of the trust-gate
  finding, and the wrong-path finding below.

## What is not landing

Steps 3–8 of the implementation plan. No seed content was found that the
mechanism is good at carrying: the first candidate turned out to be `CLAUDE.md`
content by the SDD's own §2 test and shipped there instead (#66, PR #67), and
the second was out of sync with the repository.

§9 "Why this is parked" records the reasoning, including a placement mismatch
that went unnoticed while the design was written — memory's natural unit is
per-project, but the seed rides `global-claude/`, which every project mounts. So
the mechanism can only carry cross-project content, and that splits into
always-on content (which belongs in `CLAUDE.md`) and on-demand content (a thin
category). Steps 3–8 are retained rather than deleted: the design holds within
its scope; what is in question is whether the scope is the right home.

## Two findings worth attention independent of seeding

- **#64** — this repository's `permissions.deny` rules sit at a path Claude Code
  never reads, so Phase 3's third defence layer is inert. Found by arm D of the
  gate probe: the same rule at `.claude/settings.json` fires, at the repository
  root it does not.
- **The trust gate is narrower than previously recorded.** `-p`, and any run
  whose stdout is not a TTY, skips the workspace-trust dialog. `start.sh` runs
  `-it`, so production is unaffected and the original finding stands there — but
  it had been generalised to every in-container invocation, and that does not
  hold.

## Still owed

`deny-scope` re-run in a `start.sh` container. The passing result came from a
long-lived development container, non-interactive — evidence, not proof, and the
distinction is recorded in both the script and the SDD.

## Tests

`fast` and `hostonly` both green on this branch.
