### PR TITLE
feat(skills): add project-feasibility and disambiguate its trigger (#69)

### DIFF
--- a/docs/designs/project-feasibility-skill.md
+++ b/docs/designs/project-feasibility-skill.md
@@ -1,0 +1,276 @@
+# Project Feasibility Skill
+
+## Status
+
+Draft
+
+## Context
+
+### What is missing
+
+[ADR 002](../adr/002-planning-artifact-contract.md) decision 2 assigns
+`docs/planning/feasibility.md` to a skill called `project-feasibility`.
+The template exists at `global-claude/templates/planning/feasibility.md`
+and names that owner in its frontmatter. The skill does not exist.
+
+`tests/test_planning_artifacts.bats:22-27` records the consequence
+explicitly: the suite deliberately does not assert that an owner named in
+a template is a skill that exists, because `project-feasibility` and
+`project-planning` are specified by ADR 002 and not yet built. Phase 3
+retires half of that exemption.
+
+This is the only genuinely new skill in the Planning set. `scope.md` and
+`charter.md` are the orchestrator's own opening and closing steps, and
+`prior-art.md` was routed in Phase 2 to a skill that already existed.
+
+### The trigger collides with an existing skill
+
+`swe-prior-art-research`'s description claims, in its first sentence,
+to "evaluate technical feasibility for a software engineering problem or
+idea" and to answer "whether something is technically feasible/worth
+building". A skill named `project-feasibility` competes with that on the
+most obvious keyword available.
+
+The project has already been burned by exactly this and recorded the fix.
+That skill's changelog 0.3 describes a mutual-exclusion clause against
+`industry-research-analyst` that disambiguated by keyword, failed on a
+compound query where both phrases appeared in one sentence, and was
+replaced by a tie-breaker on *what the answer needs to conclude*. The same
+failure is available here and the same fix applies.
+
+[ADR 003](../adr/003-where-a-behavioural-rule-goes.md) decision 3 raises the
+stakes: a skill's description is loaded every session and its body is not,
+so the trigger is the part that must work, and "an unfired skill is the
+failure mode that makes rung 2 worse than rung 3."
+
+### The financial dimension is not a budget
+
+ADR 001's phase mapping marks "budget estimate" and "financial-controller
+sign-off" as not applicable to a single operator, while the template
+carries a `## Financial` section with `ceiling-financial: 15`. Left
+unstated, a skill reading the word "Financial" produces currency figures
+that ADR 001 says do not belong, and does so with the false authority the
+template's Confidence section exists to prevent.
+
+## Decision
+
+### 1. One skill, one file, inheriting the Phase 2 boundary
+
+`global-claude/skills/project-feasibility/SKILL.md`. No `references/`
+subdirectory — the routing note in `swe-prior-art-research` is the
+precedent for how much fits in a body, and the three dimensions share one
+reasoning pass rather than needing separate loadable content.
+
+The global/per-project boundary is settled and not re-derived here:
+templates in the global layer, artifacts per-project, routing gated on
+`docs/planning/` existing. See
+[`planning-skill-output-routing.md`](planning-skill-output-routing.md)
+§Decision 1 and §Decision 2.
+
+One difference from `swe-prior-art-research` is load-bearing. That skill
+has a genuine non-Planning mode: asked an ad-hoc prior-art question it
+answers in the conversation and writes nothing. `project-feasibility` has
+no such mode. Its entire output is the artifact, so where
+`swe-prior-art-research` degrades to conversational output,
+`project-feasibility` declines and says what is missing.
+
+### 2. Input contract, and what refusal is for
+
+**`docs/planning/scope.md` is required.** Without it there is no problem
+statement, no constraints and no non-goals, and a feasibility verdict
+assembled from the prompt instead is precisely the failure the artifact
+exists to prevent — a confident-looking judgment about constraints nobody
+wrote down. The skill stops and names the missing file.
+
+**`docs/planning/prior-art.md` is optional.** Its absence is recorded as a
+named limitation under Confidence by dimension rather than blocking the
+run. This follows the doctrine `swe-prior-art-research` already states:
+absence of prior art is a finding, not a dead end, and usually means
+higher risk rather than opportunity.
+
+Both inputs are cited as `path §Section` and never restated, per ADR 002
+decision 6.
+
+### 3. The three dimensions do not have equal standing
+
+The template's own comment names this as the document's characteristic
+failure. The skill enforces the ordering rather than hoping for it:
+
+| Dimension | Question | Basis |
+|---|---|---|
+| Technical | Can it be built at all, under `scope.md` §Constraints | Prior art and the stack — verifiable |
+| Operational | Can *this* operator build and run it | Local to here; no literature answers it |
+| Financial | Is the expected value worth the effort | Assumption-laden; assumptions stated inline |
+
+**Financial means effort and opportunity cost — operator time, and what
+that time is not spent on. No currency figures, no budget line, no
+recurring-cost estimate.** ADR 001 excludes budget estimation from this
+project's Planning phase, and a skill that emits money anyway would be
+producing the one artifact the phase mapping says is not applicable here.
+
+`## Confidence by dimension` is mandatory and is the mechanism that makes
+the ordering visible to a reader who skips everything else. An artifact
+whose weakest section reads as firmly as its strongest has failed even if
+every claim in it is true.
+
+### 4. No new research pass
+
+The skill reads `scope.md`, `prior-art.md`, and the repository itself. It
+does not run web research.
+
+That work belongs to `swe-prior-art-research`, which has already done it
+by the time this step runs, and duplicating it costs a second research
+pass to re-derive conclusions the previous artifact already records —
+re-derivation being what ADR 002 decision 6 forbids, at roughly the token
+multiple ADR 001's context section cites for a tooled agent.
+
+### 5. Trigger, and mutual exclusion with `swe-prior-art-research`
+
+The description discriminates on what the answer must conclude, not on
+which words appear:
+
+- **"Should this project start?"** — a go/no-go judgment about a scoped
+  project, producing decision material for a human gate. This skill.
+- **"Does this already exist, and is the approach viable?"** — prior art
+  and technical viability of a solution, whether or not any project is
+  being decided. `swe-prior-art-research`.
+
+`swe-prior-art-research`'s own claim on feasibility is **not narrowed**.
+It is correct for standalone use, and narrowing it would trade a live
+collision for a dead skill. Both descriptions gain a reciprocal
+tie-breaker clause instead, matching the pattern that skill already uses
+against `industry-research-analyst`.
+
+The Planning-context reading is the sharp end: in a run that follows the
+contract, both skills fire, at different steps, in the order ADR 002
+decision 2 lays out. That is intended, not a collision.
+
+### 6. Risk inventory shape
+
+Bullets, one line per risk, each with a one-line mitigation, no narrative.
+`ceiling-risk-inventory: 20` enforces the budget; the skill states the
+reason the template gives — a risk that needs a paragraph is a scope
+problem, not a risk.
+
+### Case classification (docs-as-code-workflow.md)
+
+Case C. §4 question 1: a new global skill is a new abstraction, it
+constrains Phase 4 (the orchestrator sequences it and consumes its
+output), and it changes an existing skill's always-loaded description.
+Not Case E — nothing here touches the files §6 enumerates as container
+security controls.
+
+Recorded against #69. No ADR: ADR 002 already decided the path, the owner
+and the contract; this document decides how the owner behaves, which is
+design rather than architecture.
+
+## Consequences
+
+The Planning phase gains its only missing capability. After this, two of
+the four artifact paths have a real owner and the remaining gap is the
+orchestrator.
+
+Half the owner-existence exemption in `tests/test_planning_artifacts.bats`
+can retire. It cannot retire fully until Phase 4, so the tightening is
+staged as a check with a named exemption list rather than a comment —
+data that shrinks visibly to empty, instead of prose that has to be
+remembered.
+
+Against that: **the Financial decision is local, and the skill is global.**
+ADR 001 scopes its phase mapping to a single-operator project, but this
+skill is injected into every repository the sandbox opens. A project that
+genuinely has a budget gets a feasibility document that refuses to
+estimate cost, and nothing in the skill will tell it why. The alternative
+was worse — emitting money by default contradicts the only phase mapping
+this project has written down — but the mismatch is real and will surface
+the first time the sandbox plans something with a spend line.
+
+The refusal in decision 2 makes the skill unusable in a fresh project
+until `scope.md` exists, and `scope.md`'s owner is Phase 4. Until the
+orchestrator lands, running this skill means hand-writing a scope
+artifact. That is the intended cost of refusing to invent constraints, but
+it does mean Phase 3 ships a capability that is awkward to exercise.
+
+**Nothing tests that the right skill fires.** D-8 asserts a description
+parses; no check asserts that a feasibility question routes here rather
+than to `swe-prior-art-research`. The mutual exclusion is prose in two
+descriptions, which is rung 2 of the enforcement ladder, and the failure
+mode — the wrong skill firing, or neither — is silent. The `0.3` changelog
+entry on `swe-prior-art-research` shows this class of clause failing once
+already, and it was caught by manual re-testing rather than by a gate.
+
+## Alternatives considered
+
+**Chose:** a separate `project-feasibility` skill.
+**Rejected:** extend `swe-prior-art-research` to write `feasibility.md`
+as well.
+**Why the rejected option is attractive:** its description already claims
+feasibility, so there is no collision to resolve, no second description
+competing for the same trigger, and no new file in the global layer — the
+skill that has the prior art in hand is the obvious one to judge what it
+means.
+**What breaks if you try it anyway:** ADR 002 decision 2 gives the two
+artifacts different owners, and P-5 exists to keep that unambiguous. Worse,
+the two have opposite defaults: prior-art research is a general-purpose
+question answered in conversation, while feasibility is a contract step
+that only produces an artifact. Merging them makes every ad-hoc prior-art
+query in any repository start reaching for `docs/planning/`.
+
+**Chose:** one skill covering three dimensions.
+**Rejected:** three skills, one per dimension.
+**Why the rejected option is attractive:** the dimensions have genuinely
+different confidence profiles, which is the project's own stated reason
+for preferring composable pieces, and each would be independently
+testable.
+**What breaks if you try it anyway:** the section that carries the most
+weight is Confidence by dimension, which is a comparison — it requires all
+three judgments in one place to say which one can bear load. Three skills
+would each declare their own confidence and nothing would rank them, which
+is the failure the section was written to prevent. Three descriptions
+would also compete for one trigger, tripling the collision this design
+already has to manage once.
+
+**Chose:** refuse without `scope.md`.
+**Rejected:** derive the problem statement from the conversation when the
+artifact is absent.
+**Why the rejected option is attractive:** it keeps the skill invocable
+standalone, which the phase plan explicitly wanted for every piece, and a
+missing file is a thin reason to refuse work the model could plainly do.
+**What breaks if you try it anyway:** the artifact then asserts
+constraints and non-goals that nobody wrote down, with the authority of a
+committed document carrying `status: Draft` and a place in the index. A
+feasibility verdict is only as good as the constraints it was measured
+against, and inventing them is indistinguishable, in the output, from
+having been given them.
+
+**Chose:** no research pass of its own.
+**Rejected:** let the skill search when `prior-art.md` is thin or absent.
+**Why the rejected option is attractive:** it makes the skill complete on
+its own, and a feasibility judgment built on a thin prior-art artifact is
+genuinely weaker than one built on fresh evidence.
+**What breaks if you try it anyway:** it re-derives what the previous step
+already recorded, which ADR 002 decision 6 forbids and which costs a
+second research pass to produce a second copy that can disagree with the
+first. The honest handling of thin evidence is to say so in Confidence by
+dimension, which is what that section is for.
+
+## Implementation plan
+
+1. Write `global-claude/skills/project-feasibility/SKILL.md`: description
+   with the tie-breaker clause, input contract and refusal, the three
+   dimensions with Financial bounded to effort, the mandatory Confidence
+   section, the artifact and index-row routing from Phase 2.
+2. Add the reciprocal tie-breaker to `swe-prior-art-research`'s
+   description and a `0.5` changelog entry. Its feasibility claim is not
+   narrowed.
+3. Add `P-7` to `tests/test_planning_artifacts.bats`: every `owner:` named
+   by a template resolves to a committed skill, with `project-planning`
+   listed as a named exemption until Phase 4 lands. The exemption is an
+   array in the test, not a sentence in a comment.
+4. Verify: global-layer line ceiling (D-7), `CLAUDE.md` unchanged (D-6),
+   both descriptions still parse (D-8), markdown links resolve (D-1),
+   `P-0` through `P-7` green.
+5. Update the #69 checklist and note that owner-existence tightening is
+   now partial rather than absent.
+
+Step 4 requires `bats` on the host — `BUILDING.md:215`.

--- a/global-claude/skills/project-feasibility/SKILL.md
+++ b/global-claude/skills/project-feasibility/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: project-feasibility
+description: "Judge whether a scoped project should start — technical, operational and effort feasibility, plus a risk inventory — and write docs/planning/feasibility.md as go/no-go material for a human gate. Trigger on a Planning-phase feasibility assessment, or when docs/planning/scope.md exists and the open question is whether to proceed. Mutually exclusive with swe-prior-art-research — resolve by what the answer must conclude, not by keyword: \"should this project start\" routes here and produces a committed artifact, while \"does this already exist, and is the approach viable\" routes to swe-prior-art-research, whose findings are an input to this judgment. Requires docs/planning/scope.md and declines without it."
+---
+
+# Project Feasibility
+
+Act as the engineer who has to build the thing and will be asked why it
+slipped. The output is not an opinion on whether the idea is good — it is
+the material a human uses to decide go or no-go, honest enough that a
+no-go is a usable outcome.
+
+Producing the decision itself is not this skill's job. ADR 001 names
+autonomous go/no-go as an anti-goal: assemble the evidence, state the
+confidence, stop.
+
+## Input contract
+
+**Required — `docs/planning/scope.md`.** If it is absent, say so and stop.
+Do not derive the problem statement, the constraints or the non-goals from
+the conversation. A verdict measured against invented constraints is
+indistinguishable, in the finished artifact, from one measured against
+given ones — and the artifact is committed, indexed, and read later by
+someone who was not here.
+
+**Optional — `docs/planning/prior-art.md`.** Proceed without it, and name
+its absence in Confidence by dimension. Missing prior art usually means
+higher risk rather than opportunity.
+
+Cite both as `docs/planning/scope.md §Constraints`. Never restate what
+they say; a citation names a path and a section.
+
+**Do not run web research.** `swe-prior-art-research` owns that step and
+has already run by the time this one does. Thin evidence is reported in
+Confidence by dimension, not repaired by a second search pass that can
+disagree with the first.
+
+## Workflow
+
+1. **Read the inputs.** `scope.md` for the problem, constraints,
+   non-goals and definition of done; `prior-art.md`, if present, for what
+   exists and what it cost the people who built it. Read the repository
+   for what the stack and the tooling actually are.
+
+2. **Assess each dimension separately**, in the order below. Resist
+   letting a confident technical answer carry the other two.
+
+3. **Build the risk inventory.** Top failure modes only, one line each,
+   each with a one-line mitigation. Bulleted, no narrative. A risk that
+   needs a paragraph is a scope problem, not a risk — take it back to
+   `scope.md` rather than growing this section.
+
+4. **Rank the dimensions by how much weight each can bear**, and write
+   that into Confidence by dimension. This is the section that stops a
+   reader treating the weakest judgment as firmly as the strongest, and it
+   is the one most likely to be dropped under length pressure. Drop
+   something else.
+
+## The three dimensions
+
+| Dimension | The question | What it rests on |
+|---|---|---|
+| Technical | Can it be built at all, under the stated constraints | Prior art and the stack — verifiable, highest confidence |
+| Operational | Can *this* operator build and run it — skills, access, capacity | Local facts; no literature answers it |
+| Financial | Is the expected value worth the effort | Assumptions, stated inline |
+
+**Financial means effort and opportunity cost** — operator time, and what
+that time is not spent on. No currency figures, no budget line, no
+recurring-cost estimate. Budget estimation is outside the Planning phase
+as this project maps it, and a section that emits money produces the one
+artifact the mapping excludes, with false precision attached.
+
+## Output
+
+**Applies only when `docs/planning/` exists in the current project.**
+Its presence is the opt-in signal. Never create the directory to satisfy
+this section — without it, report the assessment in the conversation and
+write nothing.
+
+1. Follow `~/.claude/templates/planning/feasibility.md`. Its sections and
+   their order are the contract, and the `ceiling-<section>:` keys in its
+   frontmatter are hard line limits per section. What does not fit does
+   not belong in this artifact.
+2. Write `docs/planning/feasibility.md`. Frontmatter carries `status`
+   (`Draft`, `Approved`, or `Superseded by <path>`), `date`, `phase` and
+   `owner`; the `ceiling-*` and `artifact` keys stay in the template.
+   Delete the template's authoring comments from the output.
+3. Update the `feasibility.md` row in `docs/planning/README.md`: set the
+   status cell, and change the artifact name from a code span to a
+   markdown link now that the file exists. **That row only.** Every other
+   row and every other path under `docs/planning/` belongs to another
+   skill.
+
+## Notes
+
+- **Mutual exclusion with `swe-prior-art-research`**: do not disambiguate
+  by keyword — both skills legitimately use the word "feasible", and a
+  compound query contains both triggers at once. Disambiguate by what the
+  answer must conclude. A go/no-go judgment about a scoped project, ending
+  in a committed artifact, is this skill. Whether a solution already
+  exists and whether an approach is viable is `swe-prior-art-research`,
+  and its answer is an input here rather than a competitor.
+- A no-go is a first-class result. ADR 002 records that a refusal with its
+  reasoning is the most reusable output the Planning phase produces, so
+  write it with the same care as an approval and leave it in the tree with
+  its status set.
+
+## Changelog
+
+- **0.1 (draft)** — Initial version, built to the contract in
+  `docs/designs/project-feasibility-skill.md`. Not yet exercised against
+  a real `scope.md`.

--- a/global-claude/skills/swe-prior-art-research/SKILL.md
+++ b/global-claude/skills/swe-prior-art-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swe-prior-art-research
-description: "Research prior art and evaluate technical feasibility for a software engineering problem or idea — has this been solved, built, or attempted before, and is it viable given real constraints. Trigger on requests to check whether an approach/idea/problem has precedent, existing solutions, or prior attempts, or whether something is technically feasible/worth building. Mutually exclusive with industry-research-analyst — resolve by what the answer needs to conclude, not by keyword: a personal build-vs-buy decision (even phrased as \"has anyone built X\") routes here, since surveying what exists is only an input to that decision; a market/competitive landscape report routes to industry-research-analyst instead. Also distinct from technical-explanation-structure (explaining an already-identified system)."
+description: "Research prior art and evaluate technical feasibility for a software engineering problem or idea — has this been solved, built, or attempted before, and is it viable given real constraints. Trigger on requests to check whether an approach/idea/problem has precedent, existing solutions, or prior attempts, or whether something is technically feasible/worth building. Mutually exclusive with industry-research-analyst — resolve by what the answer needs to conclude, not by keyword: a personal build-vs-buy decision (even phrased as \"has anyone built X\") routes here, since surveying what exists is only an input to that decision; a market/competitive landscape report routes to industry-research-analyst instead. Also distinct from technical-explanation-structure (explaining an already-identified system). Also mutually exclusive with project-feasibility, on the same test: whether a scoped project should start, ending in a committed docs/planning/feasibility.md, routes there — whether a solution already exists and an approach is viable routes here, and is an input to that judgment."
 ---
 
 # Software Engineering Prior-Art & Feasibility Research
@@ -145,9 +145,24 @@ carries that suite.
   exists — the survey is an input, not the deliverable. If the
   deliverable itself is a landscape/competitive report, that's
   `industry-research-analyst`.
+- **Mutual exclusion with `project-feasibility`**: same tie-breaker, and
+  the keyword test fails harder here — both skills legitimately say
+  "feasible", and this one's own description claims technical feasibility.
+  Resolve on what the answer must conclude. A go/no-go judgment about a
+  scoped project, ending in a committed artifact, is `project-feasibility`.
+  Whether something exists and whether the approach is viable is this
+  skill, and the finding is an input to that judgment rather than a rival
+  to it. In a Planning run both fire, at different steps, in the order
+  ADR 002 lays out — that is intended, not a collision.
 
 ## Changelog
 
+- **0.5 (draft)** — Reciprocal mutual-exclusion clause against the new
+  `project-feasibility` skill, in the description and the notes. This
+  skill's own feasibility claim is deliberately not narrowed: it is
+  correct for standalone use, and narrowing it would trade a live
+  collision for a skill that stops firing. The tie-breaker is the same one
+  0.3 established — what the answer must conclude, not which words appear.
 - **0.4 (draft)** — Added the Planning-phase output section: in a project
   carrying `docs/planning/`, findings become `docs/planning/prior-art.md`
   under the ADR 002 contract rather than a reply. Gated on the directory

--- a/tests/test_planning_artifacts.bats
+++ b/tests/test_planning_artifacts.bats
@@ -31,12 +31,16 @@
 # same reason.
 #
 # What this suite deliberately does NOT catch:
-#   - Whether an owner named in a template is a skill that actually
-#     exists. project-feasibility and project-planning are specified by
-#     ADR 002 and not yet built, so asserting existence today would fail
-#     on purpose-built absence. Tighten this once Phase 3 and 4 land;
-#     tests/test_docs_integrity.bats D-2 already does the equivalent for
-#     the global layer.
+#   - Whether an owner that is still exempt exists. P-7 resolves every
+#     template owner to a committed skill except those in
+#     _UNBUILT_OWNERS, which today is project-planning alone — Phase 4 of
+#     #69. When that list empties the check covers all four owners with
+#     no edit to it.
+#   - Whether an owner that does exist is the skill that actually fires.
+#     P-7 resolves a path; nothing asserts that a feasibility question
+#     routes to project-feasibility rather than to
+#     swe-prior-art-research. That exclusion is prose in two
+#     descriptions, and its failure mode is silent.
 #   - Whether a skill honours path ownership at write time. P-5 checks
 #     that the ownership table is unambiguous, not that anyone obeys it.
 #   - Whether a citation points at a section that exists. D-1 in
@@ -163,6 +167,27 @@ _p5_duplicate_owners() {
     done
 }
 
+# Owners ADR 002 specifies that are not built yet. Asserting their
+# existence would fail on purpose-built absence, so they are exempt — but
+# as data rather than as a sentence in a comment, so the exemption shrinks
+# visibly and P-7 covers every owner the moment the list empties, with no
+# edit to the check itself.
+_UNBUILT_OWNERS="project-planning"
+
+_p7_missing_owner_skills() {
+    for t in $(_templates); do
+        rel="${t#${SANDBOX_DIR}/}"
+        owner="$(_fm_value "$t" owner)"
+        # A missing owner: key is P-1's finding, not this one's.
+        [ -n "$owner" ] || continue
+        case " ${_UNBUILT_OWNERS} " in
+            *" ${owner} "*) continue ;;
+        esac
+        [ -f "${SANDBOX_DIR}/global-claude/skills/${owner}/SKILL.md" ] \
+            || echo "${rel}: owner '${owner}' names no skill at global-claude/skills/${owner}/SKILL.md"
+    done
+}
+
 _p6_dead_ceiling_keys() {
     for t in $(_templates); do
         rel="${t#${SANDBOX_DIR}/}"
@@ -241,5 +266,13 @@ _report() {
     run _p6_dead_ceiling_keys
     [ "$status" -eq 0 ]
     _report "$output" "ceiling keys naming no section"
+    [ -z "$output" ]
+}
+
+# bats test_tags=fast, hostonly
+@test "P-7: every template owner outside the exemption list resolves to a skill" {
+    run _p7_missing_owner_skills
+    [ "$status" -eq 0 ]
+    _report "$output" "owners naming no committed skill"
     [ -z "$output" ]
 }


### PR DESCRIPTION
Phase 3 of #69 — `project-feasibility`, the only genuinely new skill in the Planning set. Rebased onto `main` after #72 merged.

## What changed

| Commit | |
|---|---|
| `166a7ec` | Design document |
| `f1611c6` | `global-claude/skills/project-feasibility/SKILL.md` |
| `021f57a` | Reciprocal tie-breaker in `swe-prior-art-research` |
| `32f8063` | `P-7` — template owners resolve to committed skills |

After this, three of the four artifact paths in [ADR 002](docs/adr/002-planning-artifact-contract.md) decision 2 have a real owner. The remaining gap is the orchestrator.

## The trigger collision was the real work

`swe-prior-art-research`'s description already claims, in its first sentence, to "evaluate technical feasibility" and answer "whether something is technically feasible/worth building". A skill named `project-feasibility` competes with that on the most obvious keyword available.

This project has been burned by exactly this and recorded the fix: that skill's changelog 0.3 describes a keyword-based exclusion against `industry-research-analyst` that failed on a compound query where both trigger phrases sat in one sentence, replaced by a tie-breaker on what the answer must conclude. The same fix applies here:

- **"Should this project start?"** — a go/no-go judgment ending in a committed artifact → `project-feasibility`
- **"Does this already exist, and is the approach viable?"** → `swe-prior-art-research`, whose finding is an *input* to the first

`swe-prior-art-research`'s feasibility claim is deliberately **not narrowed**. It is correct for standalone use, and narrowing it trades a live collision for a skill that stops firing — the failure ADR 003 decision 3 warns makes rung 2 worse than rung 3.

## Two design decisions worth reviewing

**The skill declines without `docs/planning/scope.md`.** It does not derive the problem statement, constraints or non-goals from the conversation. The artifact is committed, indexed, and read later by someone who was not present — a verdict measured against invented constraints is indistinguishable in the finished document from one measured against given constraints. Cost: until Phase 4 lands, exercising this skill means hand-writing a scope artifact.

**Financial means effort and opportunity cost — no currency.** ADR 001's phase mapping puts budget estimation outside this project's Planning phase. A section headed "Financial" emits money unless told not to, with false precision attached.

## Verification

`P-7` was checked in both directions, which is the part that matters:

```
owner: project-feasibility-typo   → reported                        ✓
_UNBUILT_OWNERS=""                → reports exactly the two
                                    project-planning templates      ✓
real tree                         → P-0 through P-7 pass            ✓
```

The second case is what makes the exemption load-bearing rather than decorative: it proves the list is what suppresses those findings, so deleting `project-planning` when Phase 4 lands genuinely widens coverage with no edit to the check.

Also clean: markdown links resolve, both descriptions parse, every backticked skill name in the injected layer resolves to a committed skill. Global layer 2183/3000 (D-7); `CLAUDE.md` unchanged at 96/200 (D-6).

**`bats` is not in the sandbox image** (`BUILDING.md:215`), so the above was run by extracting the helper functions rather than through bats. Needs `bats --filter-tags hostonly tests/test_planning_artifacts.bats tests/test_docs_integrity.bats` on a host before merge.

## Recorded rather than fixed

- **The Financial ruling is local; the skill is global.** ADR 001 scopes budget exclusion to a single-operator project, but this skill is injected into every repository the sandbox opens. A project with a real spend line gets a feasibility document that refuses to cost it and will not say why.
- **Nothing tests that the right skill fires.** `P-7` resolves a path. Whether a feasibility question routes here rather than to `swe-prior-art-research` is prose in two always-loaded descriptions — rung 2, silent failure, and this clause class has already failed once. Tracked on #69; no mechanism proposed.

## Still open

Phase 4 (`project-planning` orchestrator), whose exit handoff is blocked on #70. `_UNBUILT_OWNERS` empties when it lands.
