### PR TITLE
fix(skills): give commit-convention a counterweight to its own invitation

### DIFF
--- a/global-claude/skills/commit-convention/SKILL.md
+++ b/global-claude/skills/commit-convention/SKILL.md
@@ -46,9 +46,16 @@ description: >
 **Scope** (optional)
 - Noun describing the affected module in parentheses: `feat(auth): ...`
 
-**Body** (optional)
+**Body** (optional, and often the right choice is none)
 - Separate from subject with a blank line
 - Explain *what* and *why*, not *how*
+- Only the *why* that is missing elsewhere. Test each sentence against
+  the diff and against any document this commit adds: if it is already
+  there, cut it. A commit whose diff is explanatory prose — docs, a
+  design section, a long header comment — usually needs no body at all.
+- Length tracks how much of the *why* lives outside the change, not how
+  large the change is. A one-line fix with a non-obvious cause earns more
+  body than a large, self-describing documentation commit.
 
 **Footer** (optional)
 - Breaking changes: `BREAKING CHANGE: <description>`
@@ -68,4 +75,21 @@ refactor(cipher): extract padding logic into separate method
 feat(hsm): integrate PKCS#11 key derivation
 
 BREAKING CHANGE: KeyHandle no longer accepts raw byte arrays
+```
+
+Body earned — the cause is nowhere in the diff:
+
+```
+fix(entrypoint): resolve the hooks directory instead of assuming it
+
+With core.hooksPath set, the old path installed a hook git never runs
+and reported success.
+```
+
+Body not earned — the diff already says it:
+
+```
+docs(seeding): record why the feature is parked
+
+(the added section is titled "Why this is parked" and says why)
 ```


### PR DESCRIPTION
Closes #77.

`commit-convention/SKILL.md` is the artifact loaded at the moment a commit message
is written, and its body guidance said "Explain *what* and *why*, not *how*" with
nothing pulling the other way. The restraining rule — spend length only on what the
diff or a linked document cannot carry — lives in `global-claude/CLAUDE.md`, under a
section that reads as being about deliverables to the operator, in a file the author
is not thinking in at commit time. So the norm was recorded, loaded every session,
and still lost.

The audit in #77 found the pattern is not "long" but **duplicated**: the commits
that violated it were the ones whose diff already explained itself.

## What changed

An operational test rather than more emphasis, applied per sentence: check it
against the diff and against any document this commit adds, and cut what is already
there. Plus the observation that length should track how much of the *why* lives
outside the change, not how large the change is — a one-line fix with a non-obvious
cause earns more body than a large, self-describing docs commit.

Paired with two examples, an earned body next to an unearned one, since a contrast
pair does more for a style rule than another sentence of instruction.

## Why it is in the skill and not in CLAUDE.md

The rule is already in CLAUDE.md and was already ignored. More words there cost
context on every turn and would fire nowhere near the decision.

## How this gets evaluated

It does not, mechanically. There is no test for "messages got better", so this is
human review over time — #76 proposes measuring it. Deliberately no enforcement:
one file, no mechanism, trivially reversible.

The commits on this branch and on #79 are the first messages written under it.
