### PR TITLE
docs(planning): preserve the handoff branch's durable content before closing #74

### DIFF
--- a/docs/designs/planning-skill-output-routing.md
+++ b/docs/designs/planning-skill-output-routing.md
@@ -166,16 +166,18 @@ Enforcement coverage does not regress, because decision 4 moves the test
 pointer with the files and asserts the template count rather than the exit
 status.
 
-Two citations in [ADR 003](../adr/003-where-a-behavioural-rule-goes.md) go
-stale: line 30 cites `docs/planning/templates/scope.md:36-40` as the existing
-carrier for "name anti-goals", and line 77 cites `templates/scope.md` again
-in the placement table. ADRs are never rewritten, so both paths stay wrong
+Four citations in [ADR 003](../adr/003-where-a-behavioural-rule-goes.md) go
+stale, across three lines: line 30 cites both
+`docs/planning/templates/scope.md:36-40` and `templates/charter.md:20` as
+existing carriers for "name anti-goals", line 77 cites `templates/scope.md`
+again in the placement table, and line 126 cites it once more in the
+alternatives. ADRs are never rewritten, so all four paths stay wrong
 permanently. This is accepted rather than mitigated — ADR 003's decision, the
 three-rung ladder, is untouched; only the evidence for one row moved, and the
 alternative is either forking the rule into two locations or leaving the
 templates where a global skill cannot reach them. Nothing catches this
-automatically: D-1 resolves markdown links, and both citations are code
-spans.
+automatically: D-1 resolves markdown links, and every one of the four is a
+code span.
 
 Against that: the templates now live further from the artifacts they govern.
 A reader of `docs/planning/scope.md` who wants to know its ceilings must

--- a/tests/test_planning_artifacts.bats
+++ b/tests/test_planning_artifacts.bats
@@ -20,7 +20,18 @@
 #
 # All six were negative-controlled on 2026-09-04, each observed reporting
 # against a deliberately broken fixture, before the templates moved to the
-# global layer. Two of them had never been seen to fail before that.
+# global layer. P-2 and P-4 are the two that had never been seen to fail
+# before that date; naming them rather than counting them is the point,
+# since a count does not tell a later reader which results rest on the
+# thinnest evidence.
+#
+# What that verification proves is bounded by how it was performed. bats is
+# not in the sandbox image (BUILDING.md, "Running the test suite"), so from
+# inside a session the helper functions below can be extracted and called
+# directly. That exercises the awk and sed logic and nothing else — not the
+# bats wiring, not the tags, not the reporting. Any claim that a check
+# actually fires comes from a host run or from CI on a pushed branch, never
+# from a session alone.
 #
 # P-0 exists because the other five degrade to silence rather than to
 # failure. Every one of them iterates over a set, and an empty set is


### PR DESCRIPTION
Preserves the two things on `docs/planning-phase-handoff` that outlive the
plan document itself, so #74 can be closed unmerged without losing them.

That branch's purpose was briefing whoever picked up Phase 4. ADR 004
(#83, merged) settled §5.1–5.4 and #82 tracks what §5.2 left untracked, so
the briefing frame has expired. Two things on the branch were never about
the briefing.

## 1. `docs(design)` — the stale-citation correction

Cherry-picked unchanged, original authorship preserved. It corrects
`planning-skill-output-routing.md` §Consequences from "two" stale ADR 003
citations to four, across three lines.

Nothing about it relates to Phase 4. Without this commit `main` keeps
stating a count that was taken by reading the citations already known
rather than by grepping for the path — which the commit message itself
identifies as "the same class of mistake as trusting a gate nobody has
watched fail."

## 2. `test(planning)` — what the negative controls prove

Most of the handoff document's §4 was already in
`tests/test_planning_artifacts.bats`: the P-0-degrades-to-silence
rationale, the P-2/P-4 vacuity, and the fact that six checks were
negative-controlled on 2026-09-04. Two things were not.

- **Which two checks had never been seen to fail.** The header said "two of
  them" without naming them. A count does not tell a later reader which
  results rest on the thinnest evidence; P-2 and P-4 are now named.
- **How the verification was performed**, which bounds what it proves.
  `bats` is not in the sandbox image, so from inside a session the helper
  functions can be extracted and called directly — that exercises the awk
  and sed logic and none of the bats wiring, tags or reporting. A claim
  that a check actually fires has to come from a host run or from CI.

The evidence belongs beside the checks it qualifies rather than in a plan
document with a shelf life.

## Deliberately not included

§4's `_UNBUILT_OWNERS` evidence — emptying the list reports exactly the two
`project-planning` templates — describes P-7, which did not exist on `main`
when this branch was cut. Now that #73 has merged it is landable, along
with the header's "All six", which #73 leaves stale at six while adding a
seventh check. Both are follow-up.

## Merge safety

Test-merged against `feat/project-feasibility-skill` before #73 landed and
against `main` after: clean both times. The edit here sits in the header
paragraphs; #73 rewrote the "What this suite deliberately does NOT catch"
list further down the same file.

Comments only — no check logic, tags or assertions are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWkjFqVebLrHtT13pT49Tq
