### PR TITLE
test(global-layer): assert the whole injected tree arrives, not just CLAUDE.md

### DIFF
--- a/docs/designs/claude-sandbox-testing-module-sdd.md
+++ b/docs/designs/claude-sandbox-testing-module-sdd.md
@@ -221,7 +221,7 @@ Mirrors `docs/squid_proxy_guide.md` Part 3 Step 5 exactly, wrapped as assertions
 
 ### 4.4 Group 4 — Global Layer Injection
 
-G-1 through G-6 reproduce the six Phase 6 tests from `docs/plans/2026-05-global-layer-injection-v1.md`, restated as assertions rather than manual procedures. G-7 and G-8 were added later, for the entrypoint's commit-msg hook drift check (issue #54), and are the only tests in the suite that assert on entrypoint stdout — elsewhere those lines are filtered out as noise.
+G-1 through G-6 reproduce the six Phase 6 tests from `docs/plans/2026-05-global-layer-injection-v1.md`, restated as assertions rather than manual procedures. G-7 through G-9 were added later, for the entrypoint's commit-msg hook drift check (issue #54), and are the only tests in the suite that assert on entrypoint stdout — elsewhere those lines are filtered out as noise. G-10 was added last (issue #71) and is the only test that asserts on the layer as a whole rather than on a named file within it.
 
 | ID | Test | Assertion |
 |---|---|---|
@@ -233,6 +233,8 @@ G-1 through G-6 reproduce the six Phase 6 tests from `docs/plans/2026-05-global-
 | G-6 | Application-layer deny rule active | An attempted write to `/run/claude-global/` from inside a Claude Code session is blocked by `permissions.deny`, independent of the OS-level readonly mount (proves the two layers are independently effective, not just one carrying the other) |
 | G-7 | Hook drift reported | A `/workspace` whose `.git/hooks/commit-msg` differs from the shipped copy produces the entrypoint's WARNING line, the container still starts, and the drifted hook is left unmodified — the check reports, it does not resolve |
 | G-8 | Matching hook reported current | An identical installed hook produces the `OK` line and no warning. Pairs with G-7: a one-directional check cannot distinguish a working comparison from one that never fires |
+| G-9 | Hook check follows `core.hooksPath` | A repository redirecting hooks to `.githooks/` has *that* hook examined and named in the warning, and nothing is written to the `.git/hooks/` directory git does not consult |
+| G-10 | Whole layer arrives intact | For every file under `global-claude/`, a file with identical content exists at the corresponding path under `~/.claude/`, and the number compared matches the number the host holds. One-directional: files the entrypoint adds that the source lacks do not fail it |
 
 ### 4.5 Group 5 — Profile-Specific Toolchain Smoke Tests
 

--- a/tests/test_docs_integrity.bats
+++ b/tests/test_docs_integrity.bats
@@ -29,6 +29,12 @@
 #     is a breakage. D-2 scans only the latter.
 #   - Absolute or ~-relative paths (the design skill's
 #     ~/.claude/templates/... reference resolves only at container runtime).
+#     That reference is not unchecked, only uncheckable from here: G-10 in
+#     tests/test_global_layer.bats asserts every file under global-claude/
+#     arrives at the matching ~/.claude/ path, which is what makes the
+#     citation resolve in a live session. The split is engine access, not
+#     coverage — G-10 needs a running container, so it cannot live in this
+#     file (see the SDD §6.2 note on engine-gated setup()).
 
 SANDBOX_DIR="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
 

--- a/tests/test_global_layer.bats
+++ b/tests/test_global_layer.bats
@@ -118,6 +118,56 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+# bats test_tags=fast
+@test "G-10: every file in the global layer arrives in ~/.claude with its content intact" {
+    # G-1 diffs one file. entrypoint.sh copies the tree wholesale, and every
+    # consumer of the layer — ten skills, five templates, the commit-msg hook —
+    # depends on that being true for the specific file it needs. The design
+    # skill reads ~/.claude/templates/docs-as-code-workflow-template.md, a
+    # runtime path D-1 is exempted from resolving; before this test, that
+    # template could stop arriving and nothing in the repository would fail.
+    #
+    # One-directional deliberately: it walks the source tree, so the files the
+    # entrypoint legitimately adds to ~/.claude that the source has no copy of
+    # do not fail it. Coverage is the property worth asserting here; exact
+    # equality would fail on correct behaviour.
+    register_container "$CONTAINER_NAME"
+
+    # Vacuity guard, same shape as P-0 in test_planning_artifacts.bats: a mount
+    # that failed or resolved empty makes the loop below iterate zero times and
+    # report success. The count has to match what the host actually holds.
+    host_count=$(find "$GLOBAL_BASE" -type f | wc -l)
+    [ "$host_count" -gt 0 ]
+
+    # The source is already mounted readonly at /run/claude-global for every
+    # test in this file, so the comparison needs no manifest passed in — the
+    # original and the copy are both visible from inside the container.
+    run engine_run --rm --name "$CONTAINER_NAME" \
+        --mount "type=bind,source=${GLOBAL_BASE},target=/run/claude-global,readonly" \
+        claude-base bash -c '
+            cd /run/claude-global || exit 1
+            n=0
+            while IFS= read -r -d "" f; do
+                n=$((n + 1))
+                cmp -s "$f" "${HOME}/.claude/${f#./}" || echo "ABSENT-OR-DIFFERENT ${f#./}"
+            done < <(find . -type f -print0)
+            echo "CHECKED ${n}"
+        '
+    [ "$status" -eq 0 ]
+
+    # Both assertions are anchored, so the entrypoint's own "[entrypoint]   ..."
+    # listing of ~/.claude needs no filtering here (contrast G-1, which diffs
+    # raw output and must strip those lines).
+    checked=$(echo "$output" | sed -n 's/^CHECKED //p')
+    [ "$checked" -eq "$host_count" ]
+
+    if echo "$output" | grep -q '^ABSENT-OR-DIFFERENT'; then
+        echo "--- files that did not arrive intact ---" >&2
+        echo "$output" | grep '^ABSENT-OR-DIFFERENT' >&2
+        return 1
+    fi
+}
+
 # Entrypoint commit-msg hook checks (issue #54).
 #
 # These are the first tests in the suite to assert on entrypoint stdout —


### PR DESCRIPTION
Closes #71.

`base/entrypoint.sh:26` copies the global layer wholesale. Twenty files, ten
skills, five templates and the commit-msg hook depend on that. One file's
arrival was asserted.

## What G-10 does

It walks `global-claude/` from inside a live session and `cmp`s every file
against `~/.claude/`. The source is already mounted readonly at
`/run/claude-global` for every test in this file, so the original and the copy
are both visible from inside the container and no manifest has to be passed in.

One-directional on purpose. The entrypoint legitimately puts files in
`~/.claude` that the source tree has no copy of, so a symmetric diff would fail
on correct behaviour. Coverage is the property worth asserting; equality is not.

It carries a count guard for the same reason P-0 exists in
`test_planning_artifacts.bats`: a mount that failed or resolved empty makes the
loop iterate zero times and report success. The number of files compared has to
match the number the host holds.

G-1 stays. It is now redundant for one file, but when `CLAUDE.md` is what broke,
its output names the diff and G-10's does not.

## What this closes that was open

`global-claude/skills/design/SKILL.md:25` reads
`~/.claude/templates/docs-as-code-workflow-template.md`. That is a runtime path,
and `tests/test_docs_integrity.bats` exempts it from D-1 because it "resolves
only at container runtime" — so the single cross-reference into the injected
tree was excluded from the only check that resolves references, and nothing else
covered it. The template could have stopped arriving and every test in the
repository would still have passed.

The D-1 exemption note now says that G-10 is what makes that citation resolve,
and that the split is engine access rather than coverage. Leaving it unqualified
would have preserved exactly the misreading the issue is about.

`docs/designs/planning-skill-output-routing.md` records this assumption in its
Consequences and does not close it; #69 Phase 2 adds a fourth consumer to the
mechanism. That design's own pointer to #71 is left alone here — it belongs to
that branch.

## Verification

Run on the host, without an engine — the comparison logic against a simulated
copy:

- full copy: `CHECKED 20`, host count 20, no mismatches
- copy of `CLAUDE.md` alone: every one of the other 19 files reported

Not yet run, and stated rather than glossed:

- **G-10 against a real container.** Needs `./build.sh base` and
  `bats --filter-tags fast tests/test_global_layer.bats`.
- **G-10's negative control.** Reduce `base/entrypoint.sh:26` to
  `cp "$GLOBAL_SRC/CLAUDE.md" "$DEST/"`, rebuild, confirm G-10 fails while G-1
  still passes, then revert and rebuild. The edit touches a Case E file and is
  a throwaway — it must not reach a commit.

## Known limitation

G-10 needs a running engine and a built `claude-base`, so it lives in
`test_global_layer.bats` and CI does not run it
(`.github/workflows/ci.yml` filters on `hostonly`). That is permanent and it is
the honest form of the test: the alternative is a host-side check of the copy
logic that asserts the script instead of the outcome. #81 covers the assertions
that genuinely do not need an engine.

## Case

Case A — a test addition that changes no behaviour and touches none of the four
files `docs/designs/docs-as-code-workflow.md` §6 enumerates. The SDD commit also
backfills G-9, which landed with the `core.hooksPath` fix and was never added to
the table.
