### PR TITLE
test(planning): record P-7's negative control and correct P-0's scope

### DIFF
--- a/tests/test_planning_artifacts.bats
+++ b/tests/test_planning_artifacts.bats
@@ -25,6 +25,13 @@
 # since a count does not tell a later reader which results rest on the
 # thinnest evidence.
 #
+# P-7 was negative-controlled separately, after the move: emptying
+# _UNBUILT_OWNERS makes it report exactly the two project-planning
+# templates. That is what shows the exemption list is load-bearing rather
+# than decorative — the check widens to all four owners the moment the list
+# empties, so it has to be the list doing the work and not the absence of a
+# skill. Repeat that control when Phase 4 empties it for real.
+#
 # What that verification proves is bounded by how it was performed. bats is
 # not in the sandbox image (BUILDING.md, "Running the test suite"), so from
 # inside a session the helper functions below can be extracted and called
@@ -33,13 +40,13 @@
 # actually fires comes from a host run or from CI on a pushed branch, never
 # from a session alone.
 #
-# P-0 exists because the other five degrade to silence rather than to
-# failure. Every one of them iterates over a set, and an empty set is
-# reported as a pass — so a mistyped TEMPLATE_DIR turns the whole group
-# green while asserting nothing. This was not hypothetical: moving the
-# templates without moving the pointer produced exactly that, six passes
-# over zero templates. ci.yml guards --filter-tags the same way and for the
-# same reason.
+# P-0 exists because every check that reads the template set — P-1, P-3,
+# P-5, P-6 and P-7 — degrades to silence rather than to failure. Every one
+# of them iterates over that set, and an empty set is reported as a pass —
+# so a mistyped TEMPLATE_DIR turns the whole group green while asserting
+# nothing. This was not hypothetical: moving the templates without moving
+# the pointer produced exactly that, six passes over zero templates.
+# ci.yml guards --filter-tags the same way and for the same reason.
 #
 # What this suite deliberately does NOT catch:
 #   - Whether an owner that is still exempt exists. P-7 resolves every


### PR DESCRIPTION
## Summary
- Documents P-7's own negative control: emptying `_UNBUILT_OWNERS` makes the check report exactly the two `project-planning` templates, showing the exemption list is load-bearing rather than decorative.
- Corrects P-0's rationale, which said "the other five" checks degrade to silence — P-7 postdates that count, so the checks that read the template set are now named explicitly: P-1, P-3, P-5, P-6, P-7.
- Comments only. No check logic, tags, or assertions are touched.

Continuation of #85 (`91a825b`), which moved evidence for P-2/P-4 out of the Phase 4 handoff notes and into the test file's own comments on the grounds that "the evidence belongs beside the checks it qualifies rather than in a plan document with a shelf life." This finishes that for P-0/P-7.

Refs #69.

## Test plan
- [x] Comment-only diff — confirm no check logic, tags, or assertions changed (`git diff main...test/p7-verification-evidence -- tests/test_planning_artifacts.bats`)
- [x] CI passes on the branch
