### PR TITLE
feat(squid): allow primary research sources for the planning pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ check-auto-memory*.sh.out
 
 # Locat setting for claude code
 .claude/settings.local.json
+
+# test_runtime_posture.bats R-6;OOM-kill assertion 
+oom

--- a/docs/claude_code_security_plan.md
+++ b/docs/claude_code_security_plan.md
@@ -1342,3 +1342,80 @@ environment state, because the flow that would have put it there was never built
 - Nothing tests these claims. That `start.sh` passes only `GH_TOKEN` is asserted by
   reading it, and a future change adding a credential to the launch path would not
   fail anything. Compare Change 22: the same shape of gap, one layer up.
+
+---
+
+### Change 24 — Planning-Research Tier Added to the Squid Allowlist
+**Affects:** §3 (Layer 4), §5 (STRIDE Coverage Map, delta only), `squid/squid.conf`,
+`tests/test_squid_isolation.bats`. Date: 2026-09-07. Issue #91.
+
+**What changed:**
+Three `dstdomain` entries added to `squid/squid.conf` under a new
+`planning-research` tier — `arxiv.org`, `datatracker.ietf.org`,
+`www.rfc-editor.org` — with `tests/test_squid_isolation.bats` S-7/S-8/S-9
+asserting each reaches `TCP_TUNNEL/200`. No mechanism is new: same
+`dstdomain` exact-match discipline, same shared config, no `dstdom_regex`,
+no per-profile split.
+
+**Why:** `swe-prior-art-research` owns `docs/planning/prior-art.md` in the
+ADR 002 contract and is the only research skill wired into it. Its
+primary/technical source tier was unreachable — `WebFetch` against a cited
+paper or RFC was refused at the proxy — while `WebSearch` kept working,
+because it executes server-side and never transits this container's network
+stack (already recorded as F-6 in `auto-memory-seeding-step-zero.md`). The
+skill could discover sources and not read them.
+
+Two claims from the draft design behind this work were probed and
+**disproved**; recorded here so they are not carried forward:
+
+- **`claude.ai` is not required and was not added.** The draft held that
+  `WebFetch`'s domain-safety preflight calls `claude.ai/api/web/domain_info`,
+  that the missing entry denies it, and that this likely broke `WebFetch` for
+  every URL. `claude.ai` is indeed proxy-refused — and a `WebFetch` against
+  the allowlisted `code.claude.com` succeeded anyway, returning full page
+  content. The preflight is not a hard gate from inside this container.
+- **`docs.anthropic.com` is not broken.** An observed `Socket is closed`
+  against it did not reproduce; the same URL returns a clean 301 to
+  `code.claude.com`, and the apex redirects to `platform.claude.com`. Both
+  targets are already allowlisted. Transient failure, not a config gap.
+
+The same probing established, against the prior assumption, that `WebFetch`'s
+content retrieval **does** transit `HTTP_PROXY`/`HTTPS_PROXY`: a fetch of
+`arxiv.org` before this change returned `proxy refused the connection`. That
+is what makes `squid.conf` the correct control point for this gap.
+
+**STRIDE mapping (delta only):**
+
+| Threat (STRIDE) | Control changed |
+|---|---|
+| **Information Disclosure (I)** | Three new blind-tunnel exfiltration channels, in the same accepted-risk class already recorded for the reference tier in Change 15 and `squid-proxy-integration.md` §6.2-I: Squid sees only the CONNECT tunnel for HTTPS, so it restricts destination, never content. This is an incremental addition to an accepted risk, not a new category. It is stated rather than left implicit because "three more domains" is exactly the increment that accumulates without review. |
+| **Repudiation (R)** | Unchanged and still one-sided. Fetches to the new domains appear in the Squid access log; the `WebSearch` queries that found them do not, and cannot, because that tool never reaches this container. Widening what is fetchable therefore widens the fetch log without widening the search log — the visibility gap named in §5 gets proportionally larger, not smaller. Nothing here closes it. |
+
+No other STRIDE category changes: no new surface is writable, no privilege
+boundary moves, no failure mode is introduced, and the proxy's fail-closed
+startup is untouched.
+
+**Residual, not yet closed:**
+- **Exclusions are policy, not mechanism.** HN, Stack Overflow, Reddit,
+  LinkedIn, X, `dl.acm.org` and `ieeexplore.ieee.org` are excluded by a
+  comment in `squid.conf` and by nobody having added them. Default-deny means
+  an *unlisted* domain is refused, so the exclusion holds today — but a future
+  entry added by mistake fails no test. The suite asserts what is reachable,
+  never what must stay unreachable.
+- **Nothing constrains which allowed domain a session fetches.** Squid gates
+  the destination; it cannot distinguish retrieving a paper from posting to an
+  attacker-controlled path on the same host. Pre-existing, and the reason the
+  draft design proposed an application-layer gate — see the next item.
+- **`WebSearch` remains ungated and unlogged locally.** The
+  `PreToolUse`-hook layer intended to close it is not built, and the draft's
+  schema for it does not hold: `permissions.allow` merges across settings
+  scopes rather than being overridden by managed settings, so a managed
+  allow-list pre-approves rather than restricts. The key that would close it,
+  `allowManagedPermissionRulesOnly`, is managed-scope-only and all-or-nothing
+  — enabling it makes managed settings the sole source of permission rules and
+  would silently drop the deny block Change 22 moved into `.claude/settings.json`.
+  That needs its own Case E design pass, not an increment on this one.
+- **Claude Code is unpinned** (`base/Dockerfile`, `npm install -g
+  @anthropic-ai/claude-code`, no version). Any settings-schema behaviour
+  verified for that future design would be verified against whatever npm
+  served at last build.

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -57,6 +57,32 @@ acl allowed_domains dstdomain www.openssl.org
 acl allowed_domains dstdomain ctan.org
 acl allowed_domains dstdomain tug.org
 
+# ── Planning-research tier — swe-prior-art-research primary sources ───
+# Retrieval targets for the one research skill wired into the ADR 002
+# planning-artifact contract (it owns docs/planning/prior-art.md). Its
+# primary/technical source tier is papers, RFCs, and standards; none of
+# it was reachable before, so WebFetch against a cited source was
+# refused at the proxy while WebSearch (server-side, never transits this
+# container — see auto-memory-seeding-step-zero.md F-6) still returned
+# results. Discovery worked and retrieval did not. See issue #91.
+#
+# Deliberately excludes HN, Stack Overflow, Reddit, LinkedIn and X: the
+# skill's own source hierarchy treats community signal as qualitative-
+# only, never authoritative, and WebSearch snippets already surface that
+# tier without a local fetch. Also excludes dl.acm.org and
+# ieeexplore.ieee.org — both paywalled, so a fetch retrieves a landing
+# page, which is surface widened for no retrieval value. Widen only
+# against a specific cited failure, not preemptively.
+acl allowed_domains dstdomain arxiv.org
+acl allowed_domains dstdomain datatracker.ietf.org
+# Canonical RFC publisher. datatracker.ietf.org also serves RFC text, but
+# citations overwhelmingly point here, and a denied apex is invisible to
+# WebFetch — it cannot report a redirect it was never allowed to open.
+# Bare rfc-editor.org is not included: it resolves to the same Cloudflare
+# addresses and redirects to the www host, so entries for both would be
+# two ACL lines for one destination.
+acl allowed_domains dstdomain www.rfc-editor.org
+
 # ── dstdom_regex exceptions ─────────────────────────────────────────
 # Reserved for individually-justified, anchored patterns only — e.g. a
 # registry's rotating CDN-edge subdomain that a flat list can't track.

--- a/tests/test_squid_isolation.bats
+++ b/tests/test_squid_isolation.bats
@@ -25,11 +25,19 @@
 # squid.conf by mistake would not fail this suite.
 #
 # Requires a squid/ directory (Dockerfile + squid.conf) as a sibling of
-# base/crypto/systems/research, per docs/squid_proxy_guide.md Part 3 Steps
-# 1-2. That directory is not part of this repo — it's created locally by
-# the operator — so this suite cannot build or commit it (out of scope per
-# SDD §2.3); if it's missing, setup fails loudly rather than silently
-# skipping (SDD §8).
+# base/crypto/systems/research. That directory is committed: it landed in
+# 9269ddb, the commit Change 15 of docs/claude_code_security_plan.md
+# records as closing the gap where Layer 4 of the five-layer defense was
+# documentation only. So this suite builds claude-squid:test from the
+# tracked config — the same file a real session's proxy runs on, which is
+# what makes S-1..S-9 assertions about the shipped policy rather than
+# about a local copy of it.
+#
+# The existence check in setup_file() stays, and its job is narrower than
+# it looks: if squid/ is missing or incomplete, setup fails loudly instead
+# of letting the whole group skip and report green. SDD §8 step 6 records
+# the transition — before squid/ was committed, failing at setup_file()
+# was the designed behaviour rather than a defect.
 #
 # The curl helper image is pinned to docker.io/curlimages/curl:latest,
 # fully qualified — an unqualified curlimages/curl:latest depends on

--- a/tests/test_squid_isolation.bats
+++ b/tests/test_squid_isolation.bats
@@ -16,6 +16,14 @@
 # just "*.mintcdn.com") as required for img-src/connect-src, confirming
 # it's a directly-addressable host and not merely a wildcard zone.
 #
+# S-7/S-8/S-9 cover the planning-research tier from issue #91 —
+# arxiv.org, datatracker.ietf.org and www.rfc-editor.org, the
+# primary/technical sources swe-prior-art-research retrieves from. They
+# assert reachability only. Nothing here asserts that the deliberately
+# excluded UGC and paywalled domains stay excluded; S-2 covers that
+# generically via the default-deny policy, so a future entry added to
+# squid.conf by mistake would not fail this suite.
+#
 # Requires a squid/ directory (Dockerfile + squid.conf) as a sibling of
 # base/crypto/systems/research, per docs/squid_proxy_guide.md Part 3 Steps
 # 1-2. That directory is not part of this repo — it's created locally by
@@ -78,6 +86,13 @@ setup_file() {
     engine_run --rm --network claude-net \
         --env HTTPS_PROXY="http://${proxy_name}:3128" \
         docker.io/curlimages/curl:latest curl -s -o /dev/null https://mintcdn.com >&2 || true
+
+    # Planning-research tier — issue #91. S-7/S-8/S-9 assert on these.
+    for research_host in arxiv.org datatracker.ietf.org www.rfc-editor.org; do
+        engine_run --rm --network claude-net \
+            --env HTTPS_PROXY="http://${proxy_name}:3128" \
+            docker.io/curlimages/curl:latest curl -s -o /dev/null "https://${research_host}" >&2 || true
+    done
 }
 
 teardown_file() {
@@ -112,7 +127,12 @@ proxy_logs() {
     run proxy_logs
     [ "$status" -eq 0 ]
     line_count=$(echo "$output" | grep -cE '^[0-9]+\.[0-9]+[[:space:]]+[0-9]+[[:space:]]+[0-9.]+[[:space:]]+\S+/[0-9]+')
-    [ "$line_count" -ge 5 ]
+    # One line per request issued in setup_file: 5 from issue #32's era plus
+    # the 3 planning-research hosts from issue #91. Kept equal to the number
+    # of requests rather than a loose floor — a floor below the real count
+    # stops detecting a request that silently produced no log line at all,
+    # which is the failure this test exists to catch.
+    [ "$line_count" -ge 8 ]
 }
 
 # bats test_tags=slow
@@ -131,4 +151,22 @@ proxy_logs() {
 @test "S-6: request to mintcdn.com (issue #32 dstdom_regex CDN exception) succeeds" {
     run proxy_logs
     [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+mintcdn\.com:443 ]]
+}
+
+# bats test_tags=slow
+@test "S-7: request to arxiv.org (issue #91 planning-research tier) succeeds" {
+    run proxy_logs
+    [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+arxiv\.org:443 ]]
+}
+
+# bats test_tags=slow
+@test "S-8: request to datatracker.ietf.org (issue #91 planning-research tier) succeeds" {
+    run proxy_logs
+    [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+datatracker\.ietf\.org:443 ]]
+}
+
+# bats test_tags=slow
+@test "S-9: request to www.rfc-editor.org (issue #91 planning-research tier) succeeds" {
+    run proxy_logs
+    [[ "$output" =~ TCP_TUNNEL/200[[:space:]]+[0-9]+[[:space:]]+CONNECT[[:space:]]+www\.rfc-editor\.org:443 ]]
 }


### PR DESCRIPTION
## Summary
- Adds a `planning-research` tier to `squid/squid.conf` — `arxiv.org`, `datatracker.ietf.org`, `www.rfc-editor.org` — so `swe-prior-art-research` can retrieve the primary/technical sources its own hierarchy calls for. Same `dstdomain` exact-match discipline as the reference tier; no `dstdom_regex`, no per-profile split, no new mechanism.
- Adds S-7/S-8/S-9 to `tests/test_squid_isolation.bats`, and tightens S-3's floor from `-ge 5` to `-ge 8`. With 8 requests issued in `setup_file()`, a floor of 5 no longer detects a request that silently produced no access-log line, which is the failure S-3 exists to catch.
- Records Change 24 in `docs/claude_code_security_plan.md` with a STRIDE delta (I and R only) and four residual-risk items — the Case E obligation for touching `squid/squid.conf`.
- Fixes #93 (`4d6d358`, comment-only). `test_squid_isolation.bats`'s header claimed `squid/` "is not part of this repo — it's created locally by the operator", which stopped being true at `9269ddb`, and cited an `SDD §2.3` that does not exist — the document has only top-level sections §1–§9. A reader following the old text would hand-create an untracked `squid/` shadowing the reviewed config. The `SDD §8` citation was checked and kept: step 6 does document that failing at `setup_file()` was the designed behaviour before `squid/` landed.

`swe-prior-art-research` owns `docs/planning/prior-art.md` in the ADR 002 contract and is the only research skill wired into it. It could discover sources and not read them: `WebSearch` executes server-side and never transits this container, while `WebFetch` against any cited paper or RFC was refused at the proxy. The gap was retrieval, not discovery.

Two claims from the draft design behind this work were probed against a live session and **disproved**, and the commits record them rather than carrying them forward:

- **`claude.ai` is not required, and is not added here.** The draft held that `WebFetch`'s domain-safety preflight calls `claude.ai/api/web/domain_info`, that the missing allowlist entry denies it, and that this likely broke `WebFetch` for every URL. `claude.ai` is indeed proxy-refused — and a `WebFetch` against the allowlisted `code.claude.com` succeeded anyway, returning full page content.
- **`docs.anthropic.com` is not broken.** An observed `Socket is closed` did not reproduce; the same URL returns a clean 301 to `code.claude.com`, and the apex redirects to `platform.claude.com`. Both targets were already allowlisted.

The same probing established the fact this change rests on: `WebFetch`'s content retrieval **does** transit `HTTP_PROXY`/`HTTPS_PROXY` (`arxiv.org` returned `proxy refused the connection` before this change), which is what makes `squid.conf` the right control point rather than a settings-level rule.

Deliberately excluded, and recorded as decisions in the config rather than left as omissions: HN, Stack Overflow, Reddit, LinkedIn and X (the skill treats community signal as qualitative-only, and `WebSearch` snippets already surface it); `dl.acm.org` and `ieeexplore.ieee.org` (both paywalled, so a fetch retrieves a landing page — surface widened for no retrieval value).

The #93 fix is unrelated to the allowlist change and is carried here at the operator's request, as a separate comment-only commit. It touches the same file this PR already modifies, so reviewing it alongside costs less than a second PR; the split into its own commit keeps the security-relevant diff readable on its own.

Refs #91. Closes #93.

## Not in this PR

Two further pieces of the draft design are blocked rather than deferred, and Change 24's residual section records why:

- **The managed-settings + `PreToolUse` hook layer.** `permissions.allow` merges across settings scopes rather than being overridden by managed settings, so a managed allow-list pre-approves rather than restricts. The key that would close it, `allowManagedPermissionRulesOnly`, is managed-scope-only and all-or-nothing — enabling it makes managed settings the sole source of permission rules and would silently drop the deny block #79 moved into `.claude/settings.json`. Needs its own Case E pass.
- **The split read-only/read-write `/workspace` mount.** Scoped in the draft to "the headless pipeline invocation path," which does not exist — ADR 001 lists L1 as *Committed target*, and `start.sh` has one invocation and it is interactive.

Consequently `WebSearch` remains ungated and unlogged locally. This PR widens what is fetchable, and therefore widens the fetch log without widening the search log; the visibility gap gets proportionally larger, not smaller. That is stated in Change 24 rather than left implicit.

## Test plan
- [x] `./build.sh squid` — `squid.conf` parses and the image builds
- [x] `bats tests/test_squid_isolation.bats` — S-7/S-8/S-9 pass; all three new domains reach `TCP_TUNNEL/200` through the proxy
- [x] S-3 passes at the tightened `-ge 8` floor
- [x] CI passes on the branch

Run on the host as `./build.sh squid && bats tests/test_squid_isolation.bats`, green — and re-run green after `4d6d358`, confirming the comment-only change broke nothing. This had to be host-side: the sandbox has no `squid` binary, container engine, or `bats`, so nothing in this PR could be executed where it was written.

Note on what the green CI check does **not** cover: `ci.yml` runs `bats --filter-tags hostonly` and names `tests/test_squid_isolation.bats` among the suites it deliberately excludes (it needs a container engine). These tests are tagged `slow`, not `hostonly`, so CI never selects them. The operator's local run above is the only evidence S-7/S-9 hold, and a future regression in this tier would not be caught by CI.
